### PR TITLE
Bugfix/fix parser stack overflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 */.vs/*
+vs2015/dll64/
+vs2015/static/
 vs2017/dll64/
 vs2017/static/

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 */.vs/*
+vs2017/dll64/
+vs2017/static/

--- a/src/i106_decode_tmats_common.h
+++ b/src/i106_decode_tmats_common.h
@@ -173,15 +173,17 @@ Example:
 
 // Decode and store a line with no iterator (i.e. "XXX")
 #define DECODE(pattern, field)                                                  \
-    else if (strcasecmp(szCodeField, #pattern) == 0)                            \
+    if (strcasecmp(szCodeField, #pattern) == 0)                                 \
         {                                                                       \
         field = szDataItem;                                                     \
+        return 0;                                                               \
         }
+        
 
 // Decode and store a line with 1 iterator (i.e. "XXX-n")
 // "base_record_typedef" needs to match one of "GetRecordByIndex" search types defined by using the above macro
 #define DECODE_1(pattern, field, base_record_first, base_record_typedef)        \
-    else if (strcasecmp(szCodeField, #pattern) == 0)                            \
+    if (strcasecmp(szCodeField, #pattern) == 0)                                 \
         {                                                                       \
         base_record_typedef     * psuCurr;                                      \
         if (iTokens == 2)                                                       \
@@ -190,10 +192,11 @@ Example:
             assert(psuCurr != NULL);                                            \
             psuCurr->field = szDataItem;                                        \
             } /* end if sscanf OK */                                            \
+        return 0;                                                               \
         } /* end if pattern found */
 
 #define DECODE_2(pattern, field, base_record_first, base_record_typedef, record_2_first, record_2_typedef) \
-    else if (strcasecmp(szCodeField, #pattern) == 0)                            \
+    if (strcasecmp(szCodeField, #pattern) == 0)                                 \
         {                                                                       \
         base_record_typedef     * psuCurr1;                                     \
         record_2_typedef        * psuCurr2;                                     \
@@ -204,12 +207,13 @@ Example:
             psuCurr2 = psuGetRecordByIndex_##record_2_typedef(&(psuCurr1->record_2_first), iIndex2, bTRUE); \
             psuCurr2->field = szDataItem;                                                                   \
             }                                                                   \
+        return 0;                                                               \
         } /* end if pattern found */
 
 // Decode and store a comment line with 1 iterator (i.e. "x\COM-n")
 // "base_record_typedef" needs to match one of "GetRecordByIndex" search types defined by using the above macro
-#define DECODE_COMMENT(comment, base_record_first, base_record_typedef)     \
-    else if (strcasecmp(szCodeField, "COM") == 0)                               \
+#define DECODE_COMMENT(comment, base_record_first, base_record_typedef)         \
+    if (strcasecmp(szCodeField, "COM") == 0)                                    \
         {                                                                       \
         base_record_typedef     * psuCurr;                                      \
         if (iTokens == 2)                                                       \
@@ -218,6 +222,7 @@ Example:
             assert(psuCurr != NULL);                                            \
             StoreComment(comment, &(psuCurr->psuFirstComment));                 \
             } /* end if sscanf OK */                                            \
+        return 0;                                                               \
         } /* end if pattern found */
 
 /*

--- a/src/i106_decode_tmats_g.c
+++ b/src/i106_decode_tmats_g.c
@@ -151,12 +151,13 @@ int bDecodeGLine(char * szCodeName, char * szDataItem, SuGRecord ** ppsuGRecord)
     DECODE_G(SC,  szClassification)
     DECODE_G(SHA, szChecksum)
 
-    else if (strcasecmp(szCodeField, "COM") == 0)
+    if (strcasecmp(szCodeField, "COM") == 0)
         {
         StoreComment(szDataItem, &psuGRec->psuFirstComment);
+        return 0;
         }
 
-    return 0;
+    return -1;
     }
 
 

--- a/src/i106_decode_tmats_p.c
+++ b/src/i106_decode_tmats_p.c
@@ -236,7 +236,7 @@ int bDecodePLine(char * szCodeName, char * szDataItem, SuPRecord ** ppsuFirstPRe
     DECODE_P_CH7(C7FW, szCh7FirstWord)          // P-d\C7FW-n
     DECODE_P_CH7(C7NW, szNumberOfPcmWords)      // (P-d\C7NW-n)
 
-    return 0;
+    return -1;
     }
 
 

--- a/src/i106_decode_tmats_r.c
+++ b/src/i106_decode_tmats_r.c
@@ -573,7 +573,7 @@ int bDecodeRLine(char * szCodeName, char * szDataItem, SuRRecord ** ppsuFirstRRe
     DECODE_1(RT1, szTrackNumber,        psuRRec->psuFirstRefTrack, SuRRefTracks)
     DECODE_1(RT2, szReferenceFrequency, psuRRec->psuFirstRefTrack, SuRRefTracks)
 
-    return 0;
+    return -1;
     } // end bDecodeRLine
 
 

--- a/vs2015/irig106.sln
+++ b/vs2015/irig106.sln
@@ -1,0 +1,36 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 11.00
+# Visual Studio 2010
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "irig106dll", "irig106dll.vcxproj", "{5C667CC4-72E5-4524-9657-B6684B94799F}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "irig106lib", "irig106lib.vcxproj", "{58DDF7B8-678D-4F59-BA89-DBD4724FE957}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Win32 = Debug|Win32
+		Debug|x64 = Debug|x64
+		Release|Win32 = Release|Win32
+		Release|x64 = Release|x64
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{5C667CC4-72E5-4524-9657-B6684B94799F}.Debug|Win32.ActiveCfg = Debug|Win32
+		{5C667CC4-72E5-4524-9657-B6684B94799F}.Debug|Win32.Build.0 = Debug|Win32
+		{5C667CC4-72E5-4524-9657-B6684B94799F}.Debug|x64.ActiveCfg = Debug|x64
+		{5C667CC4-72E5-4524-9657-B6684B94799F}.Debug|x64.Build.0 = Debug|x64
+		{5C667CC4-72E5-4524-9657-B6684B94799F}.Release|Win32.ActiveCfg = Release|Win32
+		{5C667CC4-72E5-4524-9657-B6684B94799F}.Release|Win32.Build.0 = Release|Win32
+		{5C667CC4-72E5-4524-9657-B6684B94799F}.Release|x64.ActiveCfg = Release|x64
+		{5C667CC4-72E5-4524-9657-B6684B94799F}.Release|x64.Build.0 = Release|x64
+		{58DDF7B8-678D-4F59-BA89-DBD4724FE957}.Debug|Win32.ActiveCfg = Debug|Win32
+		{58DDF7B8-678D-4F59-BA89-DBD4724FE957}.Debug|Win32.Build.0 = Debug|Win32
+		{58DDF7B8-678D-4F59-BA89-DBD4724FE957}.Debug|x64.ActiveCfg = Debug|x64
+		{58DDF7B8-678D-4F59-BA89-DBD4724FE957}.Debug|x64.Build.0 = Debug|x64
+		{58DDF7B8-678D-4F59-BA89-DBD4724FE957}.Release|Win32.ActiveCfg = Release|Win32
+		{58DDF7B8-678D-4F59-BA89-DBD4724FE957}.Release|Win32.Build.0 = Release|Win32
+		{58DDF7B8-678D-4F59-BA89-DBD4724FE957}.Release|x64.ActiveCfg = Release|x64
+		{58DDF7B8-678D-4F59-BA89-DBD4724FE957}.Release|x64.Build.0 = Release|x64
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/vs2015/irig106dll.vcxproj
+++ b/vs2015/irig106dll.vcxproj
@@ -80,7 +80,7 @@
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>irig106dll</RootNamespace>
     <ProjectName>irig106dll</ProjectName>
-    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/vs2015/irig106dll.vcxproj
+++ b/vs2015/irig106dll.vcxproj
@@ -1,0 +1,224 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\src\i106_data_stream.c" />
+    <ClCompile Include="..\src\i106_decode_1553f1.c" />
+    <ClCompile Include="..\src\i106_decode_16pp194.c" />
+    <ClCompile Include="..\src\i106_decode_arinc429.c" />
+    <ClCompile Include="..\src\i106_decode_can.c" />
+    <ClCompile Include="..\src\i106_decode_discrete.c" />
+    <ClCompile Include="..\src\i106_decode_ethernet.c" />
+    <ClCompile Include="..\src\i106_decode_index.c" />
+    <ClCompile Include="..\src\i106_decode_pcmf1.c" />
+    <ClCompile Include="..\src\i106_decode_time.c" />
+    <ClCompile Include="..\src\i106_decode_tmats.c" />
+    <ClCompile Include="..\src\i106_decode_tmats_g.c" />
+    <ClCompile Include="..\src\i106_decode_tmats_p.c" />
+    <ClCompile Include="..\src\i106_decode_tmats_r.c" />
+    <ClCompile Include="..\src\i106_decode_uart.c" />
+    <ClCompile Include="..\src\i106_decode_video.c" />
+    <ClCompile Include="..\src\i106_index.c" />
+    <ClCompile Include="..\src\i106_time.c" />
+    <ClCompile Include="..\src\irig106ch10.c" />
+    <ClCompile Include="..\src\sha-256.c" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\src\config.h" />
+    <ClInclude Include="..\src\i106_data_stream.h" />
+    <ClInclude Include="..\src\i106_decode_1394.h" />
+    <ClInclude Include="..\src\i106_decode_1553f1.h" />
+    <ClInclude Include="..\src\i106_decode_16pp194.h" />
+    <ClInclude Include="..\src\i106_decode_arinc429.h" />
+    <ClInclude Include="..\src\i106_decode_can.h" />
+    <ClInclude Include="..\src\i106_decode_comp_gen_0.h" />
+    <ClInclude Include="..\src\i106_decode_discrete.h" />
+    <ClInclude Include="..\src\i106_decode_ethernet.h" />
+    <ClInclude Include="..\src\i106_decode_events.h" />
+    <ClInclude Include="..\src\i106_decode_image.h" />
+    <ClInclude Include="..\src\i106_decode_index.h" />
+    <ClInclude Include="..\src\i106_decode_message.h" />
+    <ClInclude Include="..\src\i106_decode_parallel.h" />
+    <ClInclude Include="..\src\i106_decode_pcmf1.h" />
+    <ClInclude Include="..\src\i106_decode_time.h" />
+    <ClInclude Include="..\src\i106_decode_tmats.h" />
+    <ClInclude Include="..\src\i106_decode_tmats_common.h" />
+    <ClInclude Include="..\src\i106_decode_tmats_g.h" />
+    <ClInclude Include="..\src\i106_decode_tmats_p.h" />
+    <ClInclude Include="..\src\i106_decode_tmats_r.h" />
+    <ClInclude Include="..\src\i106_decode_uart.h" />
+    <ClInclude Include="..\src\i106_decode_video.h" />
+    <ClInclude Include="..\src\i106_index.h" />
+    <ClInclude Include="..\src\i106_time.h" />
+    <ClInclude Include="..\src\irig106ch10.h" />
+    <ClInclude Include="..\src\irig106cl.h" />
+    <ClInclude Include="..\src\sha-256.h" />
+    <ClInclude Include="..\src\stdint.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\src\irig106dll.def" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{5C667CC4-72E5-4524-9657-B6684B94799F}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>irig106dll</RootNamespace>
+    <ProjectName>irig106dll</ProjectName>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <IntDir>$(SolutionDir)dll\$(Configuration)\</IntDir>
+    <OutDir>$(SolutionDir)dll\$(Configuration)\</OutDir>
+    <TargetName>irig106</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+    <IntDir>$(SolutionDir)dll64\$(Configuration)\</IntDir>
+    <OutDir>$(SolutionDir)dll64\$(Configuration)\</OutDir>
+    <TargetName>irig106-x64</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <IntDir>$(SolutionDir)dll\$(Configuration)\</IntDir>
+    <OutDir>$(SolutionDir)dll\$(Configuration)\</OutDir>
+    <TargetName>irig106</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+    <IntDir>$(SolutionDir)dll64\$(Configuration)\</IntDir>
+    <OutDir>$(SolutionDir)dll64\$(Configuration)\</OutDir>
+    <TargetName>irig106-x64</TargetName>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;SHA256ENABLE;IRIG_NETWORKING;_DEBUG;_WINDOWS;_USRDLL;VS2010_EXPORTS;_USE_32BIT_TIME_T;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <ModuleDefinitionFile>..\src\irig106dll.def</ModuleDefinitionFile>
+      <AdditionalDependencies>ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;SHA256ENABLE;IRIG_NETWORKING;_DEBUG;_WINDOWS;_USRDLL;VS2010_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <ModuleDefinitionFile>..\src\irig106dll.def</ModuleDefinitionFile>
+      <AdditionalDependencies>ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;SHA256ENABLE;IRIG_NETWORKING;NDEBUG;_WINDOWS;_USRDLL;VS2010_EXPORTS;_USE_32BIT_TIME_T;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <ModuleDefinitionFile>..\src\irig106dll.def</ModuleDefinitionFile>
+      <AdditionalDependencies>ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;SHA256ENABLE;IRIG_NETWORKING;NDEBUG;_WINDOWS;_USRDLL;VS2010_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <ModuleDefinitionFile>..\src\irig106dll.def</ModuleDefinitionFile>
+      <AdditionalDependencies>ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/vs2015/irig106lib.vcxproj
+++ b/vs2015/irig106lib.vcxproj
@@ -1,0 +1,206 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{58DDF7B8-678D-4F59-BA89-DBD4724FE957}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>irig106lib</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <IntDir>$(SolutionDir)static\$(Configuration)\</IntDir>
+    <OutDir>$(SolutionDir)static\$(Configuration)\</OutDir>
+    <TargetName>irig106</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <IntDir>$(SolutionDir)static\$(Configuration)\</IntDir>
+    <OutDir>$(SolutionDir)static\$(Configuration)\</OutDir>
+    <TargetName>irig106</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <IntDir>$(SolutionDir)static\$(Configuration)\</IntDir>
+    <OutDir>$(SolutionDir)static\$(Configuration)\</OutDir>
+    <TargetName>irig106</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <IntDir>$(SolutionDir)static\$(Configuration)\</IntDir>
+    <OutDir>$(SolutionDir)static\$(Configuration)\</OutDir>
+    <TargetName>irig106</TargetName>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;SHA256ENABLE;IRIG_NETWORKING;_DEBUG;_LIB;%(PreprocessorDefinitions);_USE_32BIT_TIME_T</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;SHA256ENABLE;IRIG_NETWORKING;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;SHA256ENABLE;IRIG_NETWORKING;NDEBUG;_LIB;%(PreprocessorDefinitions);_USE_32BIT_TIME_T</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;SHA256ENABLE;IRIG_NETWORKING;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <None Include="ReadMe.txt" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\src\i106_data_stream.c" />
+    <ClCompile Include="..\src\i106_decode_1553f1.c" />
+    <ClCompile Include="..\src\i106_decode_16pp194.c" />
+    <ClCompile Include="..\src\i106_decode_arinc429.c" />
+    <ClCompile Include="..\src\i106_decode_can.c" />
+    <ClCompile Include="..\src\i106_decode_discrete.c" />
+    <ClCompile Include="..\src\i106_decode_ethernet.c" />
+    <ClCompile Include="..\src\i106_decode_index.c" />
+    <ClCompile Include="..\src\i106_decode_pcmf1.c" />
+    <ClCompile Include="..\src\i106_decode_time.c" />
+    <ClCompile Include="..\src\i106_decode_tmats.c" />
+    <ClCompile Include="..\src\i106_decode_tmats_g.c" />
+    <ClCompile Include="..\src\i106_decode_tmats_p.c" />
+    <ClCompile Include="..\src\i106_decode_tmats_r.c" />
+    <ClCompile Include="..\src\i106_decode_uart.c" />
+    <ClCompile Include="..\src\i106_decode_video.c" />
+    <ClCompile Include="..\src\i106_index.c" />
+    <ClCompile Include="..\src\i106_time.c" />
+    <ClCompile Include="..\src\irig106ch10.c" />
+    <ClCompile Include="..\src\sha-256.c" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\src\config.h" />
+    <ClInclude Include="..\src\i106_data_stream.h" />
+    <ClInclude Include="..\src\i106_decode_1553f1.h" />
+    <ClInclude Include="..\src\i106_decode_16pp194.h" />
+    <ClInclude Include="..\src\i106_decode_arinc429.h" />
+    <ClInclude Include="..\src\i106_decode_can.h" />
+    <ClInclude Include="..\src\i106_decode_comp_gen_0.h" />
+    <ClInclude Include="..\src\i106_decode_discrete.h" />
+    <ClInclude Include="..\src\i106_decode_ethernet.h" />
+    <ClInclude Include="..\src\i106_decode_index.h" />
+    <ClInclude Include="..\src\i106_decode_pcmf1.h" />
+    <ClInclude Include="..\src\i106_decode_time.h" />
+    <ClInclude Include="..\src\i106_decode_tmats.h" />
+    <ClInclude Include="..\src\i106_decode_tmats_common.h" />
+    <ClInclude Include="..\src\i106_decode_tmats_g.h" />
+    <ClInclude Include="..\src\i106_decode_tmats_p.h" />
+    <ClInclude Include="..\src\i106_decode_tmats_r.h" />
+    <ClInclude Include="..\src\i106_decode_uart.h" />
+    <ClInclude Include="..\src\i106_decode_video.h" />
+    <ClInclude Include="..\src\i106_index.h" />
+    <ClInclude Include="..\src\i106_stanag_4575.h" />
+    <ClInclude Include="..\src\i106_time.h" />
+    <ClInclude Include="..\src\irig106ch10.h" />
+    <ClInclude Include="..\src\irig106cl.h" />
+    <ClInclude Include="..\src\sha-256.h" />
+    <ClInclude Include="..\src\stdint.h" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/vs2015/irig106lib.vcxproj
+++ b/vs2015/irig106lib.vcxproj
@@ -22,7 +22,7 @@
     <ProjectGuid>{58DDF7B8-678D-4F59-BA89-DBD4724FE957}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>irig106lib</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">


### PR DESCRIPTION
Fixes parser stack overflow caused by nested ifs in decode_tmats_r.c

The diff is showing additional things not a part of this PR. I think if you merge #5 first, it will clean up this PR's diff.

Please check that the error code being returned when no if is satisfied is correct. Right now it's -1, should it be something else?