### PR TITLE
Linux fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ vs2015/dll64/
 vs2015/static/
 vs2017/dll64/
 vs2017/static/
+*.o
+*.so

--- a/gcc/Makefile
+++ b/gcc/Makefile
@@ -9,7 +9,7 @@ SRC_DIR=../src
 # IRIG 106 Ch 10 Library
 # ----------------------
 
-libirig106.a: irig106ch10.o i106_time.o i106_index.o i106_decode_time.o i106_decode_1553f1.o i106_decode_tmats.o i106_decode_index.o i106_decode_uart.o i106_decode_video.o i106_decode_discrete.o i106_decode_ethernet.o i106_decode_arinc429.o i106_data_stream.o i106_decode_pcmf1.o i106_decode_analogf1.o i106_decode_can.o
+libirig106.a: irig106ch10.o i106_time.o i106_index.o i106_decode_time.o i106_decode_1553f1.o i106_decode_tmats.o i106_decode_index.o i106_decode_uart.o i106_decode_video.o i106_decode_discrete.o i106_decode_ethernet.o i106_decode_arinc429.o i106_data_stream.o i106_decode_pcmf1.o i106_decode_can.o
 	ar rc $@ $?
 
 irig106ch10.o: $(SRC_DIR)/irig106ch10.c $(SRC_DIR)/irig106ch10.h

--- a/gcc/Makefile
+++ b/gcc/Makefile
@@ -13,10 +13,10 @@ SRC_DIR=../src
 # IRIG 106 Ch 10 Library
 # ----------------------
 
-libirig106.so: irig106ch10.o i106_time.o i106_decode_time.o i106_decode_tmats.o i106_index.o i106_decode_index.o i106_decode_1553f1.o i106_decode_16pp194.o i106_decode_video.o i106_decode_ethernet.o i106_decode_arinc429.o i106_decode_tmats.o
+libirig106.so: irig106ch10.o i106_time.o i106_decode_time.o i106_decode_tmats.o i106_index.o i106_decode_index.o i106_decode_1553f1.o i106_decode_16pp194.o i106_decode_video.o i106_decode_ethernet.o i106_decode_arinc429.o i106_decode_tmats.o i106_decode_tmats_g.o i106_decode_tmats_p.o i106_decode_tmats_r.o
 	$(GCC) $(CFLAGS) -shared -o $@ $?
 
-libirig106.a: irig106ch10.o i106_time.o i106_decode_time.o i106_decode_tmats.o i106_index.o i106_decode_index.o i106_decode_1553f1.o i106_decode_16pp194.o i106_decode_video.o i106_decode_ethernet.o i106_decode_arinc429.o i106_decode_tmats.o
+libirig106.a: irig106ch10.o i106_time.o i106_decode_time.o i106_decode_tmats.o i106_index.o i106_decode_index.o i106_decode_1553f1.o i106_decode_16pp194.o i106_decode_video.o i106_decode_ethernet.o i106_decode_arinc429.o i106_decode_tmats.o i106_decode_tmats_g.o i106_decode_tmats_p.o i106_decode_tmats_r.o
 	ar rc $@ $?
 
 irig106ch10.o: $(SRC_DIR)/irig106ch10.c $(SRC_DIR)/irig106ch10.h

--- a/gcc/Makefile
+++ b/gcc/Makefile
@@ -10,7 +10,7 @@ SRC_DIR=../src
 # ----------------------
 
 libirig106.so: irig106ch10.o i106_time.o i106_index.o i106_decode_time.o i106_decode_1553f1.o i106_decode_tmats.o i106_decode_index.o i106_decode_uart.o i106_decode_video.o i106_decode_discrete.o i106_decode_ethernet.o i106_decode_arinc429.o i106_data_stream.o i106_decode_pcmf1.o i106_decode_can.o
-    $(GCC) -fPIC -shared -o libirig106.so $(SRC_DIR)/irig106ch10.c
+	$(GCC) -fPIC -shared -o libirig106.so $(SRC_DIR)/irig106ch10.c
 
 libirig106.a: irig106ch10.o i106_time.o i106_index.o i106_decode_time.o i106_decode_1553f1.o i106_decode_tmats.o i106_decode_index.o i106_decode_uart.o i106_decode_video.o i106_decode_discrete.o i106_decode_ethernet.o i106_decode_arinc429.o i106_data_stream.o i106_decode_pcmf1.o i106_decode_can.o
 	ar rc $@ $?

--- a/gcc/Makefile
+++ b/gcc/Makefile
@@ -9,10 +9,10 @@ SRC_DIR=../src
 # IRIG 106 Ch 10 Library
 # ----------------------
 
-libirig106.so: irig106ch10.o i106_time.o i106_decode_time.o i106_decode_tmats.o i106_index.o i106_decode_1553f1.o i106_decode_16pp194.o i106_decode_video.o i106_decode_ethernet.o i106_decode_arinc429.o 
+libirig106.so: irig106ch10.o i106_time.o i106_decode_time.o i106_decode_tmats.o i106_index.o i106_decode_index.o i106_decode_1553f1.o i106_decode_16pp194.o i106_decode_video.o i106_decode_ethernet.o i106_decode_arinc429.o 
 	$(GCC) $(CFLAGS) -shared -o $@ $?
 
-libirig106.a: irig106ch10.o i106_time.o i106_decode_time.o i106_decode_tmats.o i106_index.o i106_decode_1553f1.o i106_decode_16pp194.o i106_decode_video.o i106_decode_ethernet.o i106_decode_arinc429.o 
+libirig106.a: irig106ch10.o i106_time.o i106_decode_time.o i106_decode_tmats.o i106_index.o i106_decode_index.o i106_decode_1553f1.o i106_decode_16pp194.o i106_decode_video.o i106_decode_ethernet.o i106_decode_arinc429.o 
 	ar rc $@ $?
 
 irig106ch10.o: $(SRC_DIR)/irig106ch10.c $(SRC_DIR)/irig106ch10.h

--- a/gcc/Makefile
+++ b/gcc/Makefile
@@ -9,6 +9,9 @@ SRC_DIR=../src
 # IRIG 106 Ch 10 Library
 # ----------------------
 
+libirig106.so: irig106ch10.o i106_time.o i106_index.o i106_decode_time.o i106_decode_1553f1.o i106_decode_tmats.o i106_decode_index.o i106_decode_uart.o i106_decode_video.o i106_decode_discrete.o i106_decode_ethernet.o i106_decode_arinc429.o i106_data_stream.o i106_decode_pcmf1.o i106_decode_can.o
+    $(GCC) -shared -o $(SRC_DIR)/irig106ch10.c
+
 libirig106.a: irig106ch10.o i106_time.o i106_index.o i106_decode_time.o i106_decode_1553f1.o i106_decode_tmats.o i106_decode_index.o i106_decode_uart.o i106_decode_video.o i106_decode_discrete.o i106_decode_ethernet.o i106_decode_arinc429.o i106_data_stream.o i106_decode_pcmf1.o i106_decode_can.o
 	ar rc $@ $?
 
@@ -61,4 +64,4 @@ i106_decode_can.o: $(SRC_DIR)/i106_decode_can.c
 	$(GCC) $(CFLAGS) -c $(SRC_DIR)/i106_decode_can.c
 
 clean:
-	rm *.o libirig106.a
+	rm *.o *.so libirig106.a

--- a/gcc/Makefile
+++ b/gcc/Makefile
@@ -80,4 +80,4 @@ i106_decode_can.o: $(SRC_DIR)/i106_decode_can.c
 	$(GCC) $(CFLAGS) -c $(SRC_DIR)/i106_decode_can.c
 
 clean:
-	rm *.o *.so libirig106.a
+	rm --force $(SRC_DIR)/*.o $(SRC_DIR)/*.so $(SRC_DIR)/*.a

--- a/gcc/Makefile
+++ b/gcc/Makefile
@@ -10,7 +10,7 @@ SRC_DIR=../src
 # ----------------------
 
 libirig106.so: irig106ch10.o i106_time.o i106_index.o i106_decode_time.o i106_decode_1553f1.o i106_decode_tmats.o i106_decode_index.o i106_decode_uart.o i106_decode_video.o i106_decode_discrete.o i106_decode_ethernet.o i106_decode_arinc429.o i106_data_stream.o i106_decode_pcmf1.o i106_decode_can.o
-	$(GCC) -fPIC -shared -o libirig106.so $(SRC_DIR)/irig106ch10.c
+	$(GCC) $(CFLAGS) -fPIC -shared -o libirig106.so $(SRC_DIR)/irig106ch10.c
 
 libirig106.a: irig106ch10.o i106_time.o i106_index.o i106_decode_time.o i106_decode_1553f1.o i106_decode_tmats.o i106_decode_index.o i106_decode_uart.o i106_decode_video.o i106_decode_discrete.o i106_decode_ethernet.o i106_decode_arinc429.o i106_data_stream.o i106_decode_pcmf1.o i106_decode_can.o
 	ar rc $@ $?

--- a/gcc/Makefile
+++ b/gcc/Makefile
@@ -10,7 +10,7 @@ SRC_DIR=../src
 # ----------------------
 
 libirig106.so: irig106ch10.o i106_time.o i106_index.o i106_decode_time.o i106_decode_1553f1.o i106_decode_tmats.o i106_decode_index.o i106_decode_uart.o i106_decode_video.o i106_decode_discrete.o i106_decode_ethernet.o i106_decode_arinc429.o i106_data_stream.o i106_decode_pcmf1.o i106_decode_can.o
-	$(GCC) $(CFLAGS) -shared -o libirig106.so $(SRC_DIR)/irig106ch10.c
+	$(GCC) $(CFLAGS) -shared -o $@ $?
 
 libirig106.a: irig106ch10.o i106_time.o i106_index.o i106_decode_time.o i106_decode_1553f1.o i106_decode_tmats.o i106_decode_index.o i106_decode_uart.o i106_decode_video.o i106_decode_discrete.o i106_decode_ethernet.o i106_decode_arinc429.o i106_data_stream.o i106_decode_pcmf1.o i106_decode_can.o
 	ar rc $@ $?

--- a/gcc/Makefile
+++ b/gcc/Makefile
@@ -13,52 +13,52 @@ libirig106.a: irig106ch10.o i106_time.o i106_index.o i106_decode_time.o i106_dec
 	ar rc $@ $?
 
 irig106ch10.o: $(SRC_DIR)/irig106ch10.c $(SRC_DIR)/irig106ch10.h
-	$GCC $(CFLAGS) -c $(SRC_DIR)/irig106ch10.c
+	$(GCC) $(CFLAGS) -c $(SRC_DIR)/irig106ch10.c
 
 i106_time.o: $(SRC_DIR)/i106_time.c $(SRC_DIR)/i106_time.h $(SRC_DIR)/irig106ch10.h
-	$GCC $(CFLAGS) -c $(SRC_DIR)/i106_time.c
+	$(GCC) $(CFLAGS) -c $(SRC_DIR)/i106_time.c
 
 i106_index.o: $(SRC_DIR)/i106_index.c $(SRC_DIR)/i106_index.h $(SRC_DIR)/irig106ch10.h
-	$GCC $(CFLAGS) -c $(SRC_DIR)/i106_index.c
+	$(GCC) $(CFLAGS) -c $(SRC_DIR)/i106_index.c
 
 i106_decode_time.o: $(SRC_DIR)/i106_decode_time.c $(SRC_DIR)/i106_decode_time.h $(SRC_DIR)/irig106ch10.h
-	$GCC $(CFLAGS) -c $(SRC_DIR)/i106_decode_time.c
+	$(GCC) $(CFLAGS) -c $(SRC_DIR)/i106_decode_time.c
 
 i106_decode_index.o: $(SRC_DIR)/i106_decode_index.c $(SRC_DIR)/i106_decode_index.h $(SRC_DIR)/irig106ch10.h
-	$GCC $(CFLAGS) -c $(SRC_DIR)/i106_decode_index.c
+	$(GCC) $(CFLAGS) -c $(SRC_DIR)/i106_decode_index.c
 
 i106_decode_1553f1.o: $(SRC_DIR)/i106_decode_1553f1.c $(SRC_DIR)/i106_decode_1553f1.h $(SRC_DIR)/irig106ch10.h
-	$GCC $(CFLAGS) -c $(SRC_DIR)/i106_decode_1553f1.c
+	$(GCC) $(CFLAGS) -c $(SRC_DIR)/i106_decode_1553f1.c
 
 i106_decode_tmats.o: $(SRC_DIR)/i106_decode_tmats.c $(SRC_DIR)/i106_decode_tmats.h $(SRC_DIR)/irig106ch10.h
-	$GCC $(CFLAGS) -c $(SRC_DIR)/i106_decode_tmats.c
+	$(GCC) $(CFLAGS) -c $(SRC_DIR)/i106_decode_tmats.c
 
 i106_decode_uart.o: $(SRC_DIR)/i106_decode_uart.c
-	$GCC $(CFLAGS) -c $(SRC_DIR)/i106_decode_uart.c
+	$(GCC) $(CFLAGS) -c $(SRC_DIR)/i106_decode_uart.c
 
 i106_decode_video.o: $(SRC_DIR)/i106_decode_video.c
-	$GCC $(CFLAGS) -c $(SRC_DIR)/i106_decode_video.c
+	$(GCC) $(CFLAGS) -c $(SRC_DIR)/i106_decode_video.c
 
 i106_decode_discrete.o: $(SRC_DIR)/i106_decode_discrete.c
-	$GCC $(CFLAGS) -c $(SRC_DIR)/i106_decode_discrete.c
+	$(GCC) $(CFLAGS) -c $(SRC_DIR)/i106_decode_discrete.c
 
 i106_decode_ethernet.o: $(SRC_DIR)/i106_decode_ethernet.c
-	$GCC $(CFLAGS) -c $(SRC_DIR)/i106_decode_ethernet.c
+	$(GCC) $(CFLAGS) -c $(SRC_DIR)/i106_decode_ethernet.c
 
 i106_decode_arinc429.o: $(SRC_DIR)/i106_decode_arinc429.c
-	$GCC $(CFLAGS) -c $(SRC_DIR)/i106_decode_arinc429.c
+	$(GCC) $(CFLAGS) -c $(SRC_DIR)/i106_decode_arinc429.c
 
 i106_data_stream.o: $(SRC_DIR)/i106_data_stream.c
-	$GCC $(CFLAGS) -c $(SRC_DIR)/i106_data_stream.c
+	$(GCC) $(CFLAGS) -c $(SRC_DIR)/i106_data_stream.c
 
 i106_decode_pcmf1.o: $(SRC_DIR)/i106_decode_pcmf1.c
-	$GCC $(CFLAGS) -c $(SRC_DIR)/i106_decode_pcmf1.c
+	$(GCC) $(CFLAGS) -c $(SRC_DIR)/i106_decode_pcmf1.c
 
 i106_decode_analogf1.o: $(SRC_DIR)/i106_decode_analogf1.c
-	$GCC $(CFLAGS) -c $(SRC_DIR)/i106_decode_analogf1.c
+	$(GCC) $(CFLAGS) -c $(SRC_DIR)/i106_decode_analogf1.c
 
 i106_decode_can.o: $(SRC_DIR)/i106_decode_can.c
-	$GCC $(CFLAGS) -c $(SRC_DIR)/i106_decode_can.c
+	$(GCC) $(CFLAGS) -c $(SRC_DIR)/i106_decode_can.c
 
 clean:
 	rm *.o libirig106.a

--- a/gcc/Makefile
+++ b/gcc/Makefile
@@ -2,6 +2,10 @@
 # Makefile - A makefile for the IRIG 106 Chapter 10 library
 # ---------------------------------------------------------------------------
 
+ifeq ($(GCC),)
+GCC := gcc
+endif
+
 CFLAGS=-D_FILE_OFFSET_BITS=64 -D_LARGEFILE64_SOURCE -ggdb -fpack-struct=1 -fPIC
 
 SRC_DIR=../src
@@ -33,8 +37,17 @@ i106_decode_index.o: $(SRC_DIR)/i106_decode_index.c $(SRC_DIR)/i106_decode_index
 i106_decode_1553f1.o: $(SRC_DIR)/i106_decode_1553f1.c $(SRC_DIR)/i106_decode_1553f1.h $(SRC_DIR)/irig106ch10.h
 	$(GCC) $(CFLAGS) -c $(SRC_DIR)/i106_decode_1553f1.c
 
-i106_decode_tmats.o: $(SRC_DIR)/i106_decode_tmats.c $(SRC_DIR)/i106_decode_tmats.h $(SRC_DIR)/irig106ch10.h
+i106_decode_tmats.o: $(SRC_DIR)/i106_decode_tmats.c $(SRC_DIR)/i106_decode_tmats.h $(SRC_DIR)/irig106ch10.h $(SRC_DIR)/i106_decode_tmats_g.o $(SRC_DIR)/i106_decode_tmats_p.o $(SRC_DIR)/i106_decode_tmats_r.o
 	$(GCC) $(CFLAGS) -c $(SRC_DIR)/i106_decode_tmats.c
+
+i106_decode_tmats_g.o: $(SRC_DIR)/i106_decode_tmats_g.c $(SRC_DIR)/i106_decode_tmats_g.h $(SRC_DIR)/irig106ch10.h
+	$(GCC) $(CFLAGS) -c $(SRC_DIR)/i106_decode_tmats_g.c
+
+i106_decode_tmats_p.o: $(SRC_DIR)/i106_decode_tmats_p.c $(SRC_DIR)/i106_decode_tmats_p.h $(SRC_DIR)/irig106ch10.h
+	$(GCC) $(CFLAGS) -c $(SRC_DIR)/i106_decode_tmats_p.c
+
+i106_decode_tmats_r.o: $(SRC_DIR)/i106_decode_tmats_r.c $(SRC_DIR)/i106_decode_tmats_r.h $(SRC_DIR)/irig106ch10.h
+	$(GCC) $(CFLAGS) -c $(SRC_DIR)/i106_decode_tmats_r.c
 
 i106_decode_uart.o: $(SRC_DIR)/i106_decode_uart.c
 	$(GCC) $(CFLAGS) -c $(SRC_DIR)/i106_decode_uart.c
@@ -50,7 +63,7 @@ i106_decode_ethernet.o: $(SRC_DIR)/i106_decode_ethernet.c
 
 i106_decode_arinc429.o: $(SRC_DIR)/i106_decode_arinc429.c
 	$(GCC) $(CFLAGS) -c $(SRC_DIR)/i106_decode_arinc429.c
-    
+
 i106_decode_16pp194.o: $(SRC_DIR)/i106_decode_16pp194.c
 	$(GCC) $(CFLAGS) -c $(SRC_DIR)/i106_decode_16pp194.c
 

--- a/gcc/Makefile
+++ b/gcc/Makefile
@@ -13,52 +13,52 @@ libirig106.a: irig106ch10.o i106_time.o i106_index.o i106_decode_time.o i106_dec
 	ar rc $@ $?
 
 irig106ch10.o: $(SRC_DIR)/irig106ch10.c $(SRC_DIR)/irig106ch10.h
-	gcc $(CFLAGS) -c $(SRC_DIR)/irig106ch10.c
+	$GCC $(CFLAGS) -c $(SRC_DIR)/irig106ch10.c
 
 i106_time.o: $(SRC_DIR)/i106_time.c $(SRC_DIR)/i106_time.h $(SRC_DIR)/irig106ch10.h
-	gcc $(CFLAGS) -c $(SRC_DIR)/i106_time.c
+	$GCC $(CFLAGS) -c $(SRC_DIR)/i106_time.c
 
 i106_index.o: $(SRC_DIR)/i106_index.c $(SRC_DIR)/i106_index.h $(SRC_DIR)/irig106ch10.h
-	gcc $(CFLAGS) -c $(SRC_DIR)/i106_index.c
+	$GCC $(CFLAGS) -c $(SRC_DIR)/i106_index.c
 
 i106_decode_time.o: $(SRC_DIR)/i106_decode_time.c $(SRC_DIR)/i106_decode_time.h $(SRC_DIR)/irig106ch10.h
-	gcc $(CFLAGS) -c $(SRC_DIR)/i106_decode_time.c
+	$GCC $(CFLAGS) -c $(SRC_DIR)/i106_decode_time.c
 
 i106_decode_index.o: $(SRC_DIR)/i106_decode_index.c $(SRC_DIR)/i106_decode_index.h $(SRC_DIR)/irig106ch10.h
-	gcc $(CFLAGS) -c $(SRC_DIR)/i106_decode_index.c
+	$GCC $(CFLAGS) -c $(SRC_DIR)/i106_decode_index.c
 
 i106_decode_1553f1.o: $(SRC_DIR)/i106_decode_1553f1.c $(SRC_DIR)/i106_decode_1553f1.h $(SRC_DIR)/irig106ch10.h
-	gcc $(CFLAGS) -c $(SRC_DIR)/i106_decode_1553f1.c
+	$GCC $(CFLAGS) -c $(SRC_DIR)/i106_decode_1553f1.c
 
 i106_decode_tmats.o: $(SRC_DIR)/i106_decode_tmats.c $(SRC_DIR)/i106_decode_tmats.h $(SRC_DIR)/irig106ch10.h
-	gcc $(CFLAGS) -c $(SRC_DIR)/i106_decode_tmats.c
+	$GCC $(CFLAGS) -c $(SRC_DIR)/i106_decode_tmats.c
 
 i106_decode_uart.o: $(SRC_DIR)/i106_decode_uart.c
-	gcc $(CFLAGS) -c $(SRC_DIR)/i106_decode_uart.c
+	$GCC $(CFLAGS) -c $(SRC_DIR)/i106_decode_uart.c
 
 i106_decode_video.o: $(SRC_DIR)/i106_decode_video.c
-	gcc $(CFLAGS) -c $(SRC_DIR)/i106_decode_video.c
+	$GCC $(CFLAGS) -c $(SRC_DIR)/i106_decode_video.c
 
 i106_decode_discrete.o: $(SRC_DIR)/i106_decode_discrete.c
-	gcc $(CFLAGS) -c $(SRC_DIR)/i106_decode_discrete.c
+	$GCC $(CFLAGS) -c $(SRC_DIR)/i106_decode_discrete.c
 
 i106_decode_ethernet.o: $(SRC_DIR)/i106_decode_ethernet.c
-	gcc $(CFLAGS) -c $(SRC_DIR)/i106_decode_ethernet.c
+	$GCC $(CFLAGS) -c $(SRC_DIR)/i106_decode_ethernet.c
 
 i106_decode_arinc429.o: $(SRC_DIR)/i106_decode_arinc429.c
-	gcc $(CFLAGS) -c $(SRC_DIR)/i106_decode_arinc429.c
+	$GCC $(CFLAGS) -c $(SRC_DIR)/i106_decode_arinc429.c
 
 i106_data_stream.o: $(SRC_DIR)/i106_data_stream.c
-	gcc $(CFLAGS) -c $(SRC_DIR)/i106_data_stream.c
+	$GCC $(CFLAGS) -c $(SRC_DIR)/i106_data_stream.c
 
 i106_decode_pcmf1.o: $(SRC_DIR)/i106_decode_pcmf1.c
-	gcc $(CFLAGS) -c $(SRC_DIR)/i106_decode_pcmf1.c
+	$GCC $(CFLAGS) -c $(SRC_DIR)/i106_decode_pcmf1.c
 
 i106_decode_analogf1.o: $(SRC_DIR)/i106_decode_analogf1.c
-	gcc $(CFLAGS) -c $(SRC_DIR)/i106_decode_analogf1.c
+	$GCC $(CFLAGS) -c $(SRC_DIR)/i106_decode_analogf1.c
 
 i106_decode_can.o: $(SRC_DIR)/i106_decode_can.c
-	gcc $(CFLAGS) -c $(SRC_DIR)/i106_decode_can.c
+	$GCC $(CFLAGS) -c $(SRC_DIR)/i106_decode_can.c
 
 clean:
 	rm *.o libirig106.a

--- a/gcc/Makefile
+++ b/gcc/Makefile
@@ -9,10 +9,10 @@ SRC_DIR=../src
 # IRIG 106 Ch 10 Library
 # ----------------------
 
-libirig106.so: irig106ch10.o i106_time.o i106_decode_time.o i106_decode_tmats.o i106_index.o i106_decode_index.o i106_decode_1553f1.o i106_decode_16pp194.o i106_decode_video.o i106_decode_ethernet.o i106_decode_arinc429.o 
+libirig106.so: irig106ch10.o i106_time.o i106_decode_time.o i106_decode_tmats.o i106_index.o i106_decode_index.o i106_decode_1553f1.o i106_decode_16pp194.o i106_decode_video.o i106_decode_ethernet.o i106_decode_arinc429.o i106_decode_tmats.o
 	$(GCC) $(CFLAGS) -shared -o $@ $?
 
-libirig106.a: irig106ch10.o i106_time.o i106_decode_time.o i106_decode_tmats.o i106_index.o i106_decode_index.o i106_decode_1553f1.o i106_decode_16pp194.o i106_decode_video.o i106_decode_ethernet.o i106_decode_arinc429.o 
+libirig106.a: irig106ch10.o i106_time.o i106_decode_time.o i106_decode_tmats.o i106_index.o i106_decode_index.o i106_decode_1553f1.o i106_decode_16pp194.o i106_decode_video.o i106_decode_ethernet.o i106_decode_arinc429.o i106_decode_tmats.o
 	ar rc $@ $?
 
 irig106ch10.o: $(SRC_DIR)/irig106ch10.c $(SRC_DIR)/irig106ch10.h

--- a/gcc/Makefile
+++ b/gcc/Makefile
@@ -2,7 +2,7 @@
 # Makefile - A makefile for the IRIG 106 Chapter 10 library
 # ---------------------------------------------------------------------------
 
-CFLAGS=-D_FILE_OFFSET_BITS=64 -D_LARGEFILE64_SOURCE -ggdb -fpack-struct=1
+CFLAGS=-D_FILE_OFFSET_BITS=64 -D_LARGEFILE64_SOURCE -ggdb -fpack-struct=1 -fPIC
 
 SRC_DIR=../src
 
@@ -10,7 +10,7 @@ SRC_DIR=../src
 # ----------------------
 
 libirig106.so: irig106ch10.o i106_time.o i106_index.o i106_decode_time.o i106_decode_1553f1.o i106_decode_tmats.o i106_decode_index.o i106_decode_uart.o i106_decode_video.o i106_decode_discrete.o i106_decode_ethernet.o i106_decode_arinc429.o i106_data_stream.o i106_decode_pcmf1.o i106_decode_can.o
-	$(GCC) $(CFLAGS) -fPIC -shared -o libirig106.so $(SRC_DIR)/irig106ch10.c
+	$(GCC) $(CFLAGS) -shared -o libirig106.so $(SRC_DIR)/irig106ch10.c
 
 libirig106.a: irig106ch10.o i106_time.o i106_index.o i106_decode_time.o i106_decode_1553f1.o i106_decode_tmats.o i106_decode_index.o i106_decode_uart.o i106_decode_video.o i106_decode_discrete.o i106_decode_ethernet.o i106_decode_arinc429.o i106_data_stream.o i106_decode_pcmf1.o i106_decode_can.o
 	ar rc $@ $?

--- a/gcc/Makefile
+++ b/gcc/Makefile
@@ -9,10 +9,10 @@ SRC_DIR=../src
 # IRIG 106 Ch 10 Library
 # ----------------------
 
-libirig106.so: irig106ch10.o i106_time.o i106_index.o i106_decode_time.o i106_decode_1553f1.o i106_decode_tmats.o i106_decode_index.o i106_decode_uart.o i106_decode_video.o i106_decode_discrete.o i106_decode_ethernet.o i106_decode_arinc429.o i106_data_stream.o i106_decode_pcmf1.o i106_decode_can.o
+libirig106.so: irig106ch10.o i106_time.o i106_decode_time.o i106_decode_tmats.o i106_index.o i106_decode_1553f1.o i106_decode_16pp194.o i106_decode_video.o i106_decode_ethernet.o i106_decode_arinc429.o 
 	$(GCC) $(CFLAGS) -shared -o $@ $?
 
-libirig106.a: irig106ch10.o i106_time.o i106_index.o i106_decode_time.o i106_decode_1553f1.o i106_decode_tmats.o i106_decode_index.o i106_decode_uart.o i106_decode_video.o i106_decode_discrete.o i106_decode_ethernet.o i106_decode_arinc429.o i106_data_stream.o i106_decode_pcmf1.o i106_decode_can.o
+libirig106.a: irig106ch10.o i106_time.o i106_decode_time.o i106_decode_tmats.o i106_index.o i106_decode_1553f1.o i106_decode_16pp194.o i106_decode_video.o i106_decode_ethernet.o i106_decode_arinc429.o 
 	ar rc $@ $?
 
 irig106ch10.o: $(SRC_DIR)/irig106ch10.c $(SRC_DIR)/irig106ch10.h
@@ -50,6 +50,9 @@ i106_decode_ethernet.o: $(SRC_DIR)/i106_decode_ethernet.c
 
 i106_decode_arinc429.o: $(SRC_DIR)/i106_decode_arinc429.c
 	$(GCC) $(CFLAGS) -c $(SRC_DIR)/i106_decode_arinc429.c
+    
+i106_decode_16pp194.o: $(SRC_DIR)/i106_decode_16pp194.c
+	$(GCC) $(CFLAGS) -c $(SRC_DIR)/i106_decode_16pp194.c
 
 i106_data_stream.o: $(SRC_DIR)/i106_data_stream.c
 	$(GCC) $(CFLAGS) -c $(SRC_DIR)/i106_data_stream.c

--- a/gcc/Makefile
+++ b/gcc/Makefile
@@ -37,7 +37,7 @@ i106_decode_index.o: $(SRC_DIR)/i106_decode_index.c $(SRC_DIR)/i106_decode_index
 i106_decode_1553f1.o: $(SRC_DIR)/i106_decode_1553f1.c $(SRC_DIR)/i106_decode_1553f1.h $(SRC_DIR)/irig106ch10.h
 	$(GCC) $(CFLAGS) -c $(SRC_DIR)/i106_decode_1553f1.c
 
-i106_decode_tmats.o: $(SRC_DIR)/i106_decode_tmats.c $(SRC_DIR)/i106_decode_tmats.h $(SRC_DIR)/irig106ch10.h $(SRC_DIR)/i106_decode_tmats_g.o $(SRC_DIR)/i106_decode_tmats_p.o $(SRC_DIR)/i106_decode_tmats_r.o
+i106_decode_tmats.o: $(SRC_DIR)/i106_decode_tmats.c $(SRC_DIR)/i106_decode_tmats.h $(SRC_DIR)/irig106ch10.h i106_decode_tmats_g.o i106_decode_tmats_p.o i106_decode_tmats_r.o
 	$(GCC) $(CFLAGS) -c $(SRC_DIR)/i106_decode_tmats.c
 
 i106_decode_tmats_g.o: $(SRC_DIR)/i106_decode_tmats_g.c $(SRC_DIR)/i106_decode_tmats_g.h $(SRC_DIR)/irig106ch10.h
@@ -80,4 +80,4 @@ i106_decode_can.o: $(SRC_DIR)/i106_decode_can.c
 	$(GCC) $(CFLAGS) -c $(SRC_DIR)/i106_decode_can.c
 
 clean:
-	rm --force $(SRC_DIR)/*.o $(SRC_DIR)/*.so $(SRC_DIR)/*.a
+	rm --force *.o *.so *.a

--- a/gcc/Makefile
+++ b/gcc/Makefile
@@ -10,7 +10,7 @@ SRC_DIR=../src
 # ----------------------
 
 libirig106.so: irig106ch10.o i106_time.o i106_index.o i106_decode_time.o i106_decode_1553f1.o i106_decode_tmats.o i106_decode_index.o i106_decode_uart.o i106_decode_video.o i106_decode_discrete.o i106_decode_ethernet.o i106_decode_arinc429.o i106_data_stream.o i106_decode_pcmf1.o i106_decode_can.o
-    $(GCC) -shared -o $(SRC_DIR)/irig106ch10.c
+    $(GCC) -fPIC -shared -o libirig106.so $(SRC_DIR)/irig106ch10.c
 
 libirig106.a: irig106ch10.o i106_time.o i106_index.o i106_decode_time.o i106_decode_1553f1.o i106_decode_tmats.o i106_decode_index.o i106_decode_uart.o i106_decode_video.o i106_decode_discrete.o i106_decode_ethernet.o i106_decode_arinc429.o i106_data_stream.o i106_decode_pcmf1.o i106_decode_can.o
 	ar rc $@ $?

--- a/src/i106_decode_time.c
+++ b/src/i106_decode_time.c
@@ -411,8 +411,6 @@ EnI106Status I106_CALL_DECL
     else
         psuTimeF1->suChanSpec.bLeapYear = 0;
 
-#pragma message("WARNING - Don't zero out the whole packet")
-
     // Fill in day of year format
     if (uFmtDate == 0)
         {

--- a/src/i106_decode_tmats.c
+++ b/src/i106_decode_tmats.c
@@ -229,7 +229,7 @@ EnI106Status I106_CALL_DECL
         szDataItem = psuTmatsInfo->pasuTmatsLines[iLineIdx].szDataItem;
 
         // Decode comments
-        if (stricmp(szCodeName, "COMMENT") == 0)
+        if (strcasecmp(szCodeName, "COMMENT") == 0)
             {
             StoreComment(szDataItem, &(psuTmatsInfo->psuFirstComment));
             } // end if comment

--- a/src/irig106ch10.c
+++ b/src/irig106ch10.c
@@ -45,13 +45,13 @@
 
 #if defined(__GNUC__)
 #include <sys/io.h>
+#include <unistd.h>
 #else
 #include <io.h>
 #endif
 
 #if defined(IRIG_NETWORKING) & !defined(_WIN32)
 #include <sys/types.h>
-#include <unistd.h>
 #endif
 
 #include "config.h"

--- a/src/irig106dll.def
+++ b/src/irig106dll.def
@@ -66,7 +66,7 @@ EXPORTS
     enI106_Decode_Next1553F1
     i1553WordCnt
 
-; i106_decoe_16pp194
+; i106_decode_16pp194
     enI106_Decode_First16PP194
     enI106_Decode_Next16PP194
 


### PR DESCRIPTION
I made a number of fixes to get the lib compiling on linux with gcc.

I needed a shared object .so file, so added that to the makefile. I'm compiling with conda's gcc and binutils so I needed to make the gcc calls use the env var they set up. The check at the beginning of the makefile sets the gcc var to the default "gcc" if not defined.

The analog and pcm modules still have problems and are not compiled in the static or shared object files. Tmats has been updated for the g, p, and r files.