### PR TITLE
Change MsgDecodeTMATS.py to work with Python 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ vs2017/static/
 *.o
 *.a
 *.so
+__pycache__

--- a/python/Py106/MsgDecodeTMATS.py
+++ b/python/Py106/MsgDecodeTMATS.py
@@ -86,7 +86,7 @@ class TMATS_Info(ctypes.Structure):
                 ("FirstHRecord",        ctypes.c_void_p),
                 ("FirstVRecord",        ctypes.c_void_p),
                 ("FirstMemBlock",       ctypes.c_void_p)]
-    
+
 # ---------------------------------------------------------------------------
 # Direct calls into the IRIG 106 dll
 # ---------------------------------------------------------------------------
@@ -106,7 +106,7 @@ def I106_Tmats_Find(tmats_info, tmats_code):
     if tmats_value is None:
         return ""
     else:
-        return tmats_value.decode()
+        return tmats_value
 
 def I106_Free_TmatsInfo(tmats_info):
     Packet.IrigDataDll.enI106_Free_TmatsInfo(ctypes.byref(tmats_info))
@@ -129,7 +129,7 @@ class DecodeTMATS(object):
         ''' Constructor '''
         self.PacketIO  = PacketIO
         self.TmatsInfo = TMATS_Info()
-        
+
     def decode_tmats(self):
         ret_status= I106_Decode_TMATS(self.PacketIO.Header, self.PacketIO.Buffer, self.TmatsInfo)
         return ret_status
@@ -146,26 +146,26 @@ class DecodeTMATS(object):
     def free_tmatsinfo(self):
         I106_Free_TmatsInfo(self.TmatsInfo)
         return
-        
+
 
 # ---------------------------------------------------------------------------
 # Module initialization
 # ---------------------------------------------------------------------------
 
 
-# This test code just opens an IRIG file and prints some time 
-    
+# This test code just opens an IRIG file and prints some time
+
 if __name__=='__main__':
-    
+
     print ("IRIG 106 Decode TMATS")
-    
+
 #    import Time
-    
+
     # Make IRIG 106 library classes
     PktIO       = Packet.IO()
     TmatsDecode = DecodeTMATS(PktIO)
     DataType    = Packet.DataType()
-    
+
     if len(sys.argv) > 1 :
         RetStatus = PktIO.open(sys.argv[1], Packet.FileMode.READ)
         if RetStatus != Status.OK :
@@ -181,19 +181,18 @@ if __name__=='__main__':
             status = TmatsDecode.decode_tmats()
 #            print (TmatsDecode.irig_time)
             break
-            
+
     PktIO.close()
-    
-#    ProgramName = TmatsDecode.TmatsInfo.FirstGRecord.contents.ProgramName    
+
+#    ProgramName = TmatsDecode.TmatsInfo.FirstGRecord.contents.ProgramName
 #    print("Program Name : {0}".format(TmatsDecode.TmatsInfo.FirstGRecord.contents.ProgramName))
     ProgramName  = TmatsDecode.find("G\\PN")
     IrigVersion  = TmatsDecode.TmatsInfo.Ch10Version
     TmatsVersion = TmatsDecode.find("G\\106")
-    
+
     print("File Name     : {0}".format(sys.argv[1]))
-    print("Program Name  : {0}".format(ProgramName.decode()))
+    print("Program Name  : {0}".format(ProgramName))
     print("IRIG Version  : {0}".format(IrigVersion))
-    print("TMATS Version : {0}".format(TmatsVersion.decode()))
-    
+    print("TMATS Version : {0}".format(TmatsVersion))
+
     TmatsDecode.free_tmatsinfo()
-    


### PR DESCRIPTION
Removed calling `decode()` method on objects of the `str` class. Running this version on a few Ch10 files did not generate any error.