### PR TITLE
Export decode index functions

### DIFF
--- a/src/irig106dll.def
+++ b/src/irig106dll.def
@@ -57,6 +57,10 @@ EXPORTS
     enI106_Encode_Tmats
     enI106_Tmats_Signature
 
+; i106_decode_index
+    enI106_Decode_FirstIndex
+    enI106_Decode_NextIndex
+
 ; i106_index
     enIndexPresent
     enReadIndexes


### PR DESCRIPTION
Sorry for the messy commit history. Only change is to add the decode index functions to the built dll.