### PR TITLE
Remove the -fpack-struct=1 compiler flag

### DIFF
--- a/gcc/Makefile
+++ b/gcc/Makefile
@@ -6,7 +6,7 @@ ifeq ($(GCC),)
 GCC := gcc
 endif
 
-CFLAGS=-D_FILE_OFFSET_BITS=64 -D_LARGEFILE64_SOURCE -ggdb -fpack-struct=1 -fPIC
+CFLAGS=-D_FILE_OFFSET_BITS=64 -D_LARGEFILE64_SOURCE -ggdb -fPIC
 
 SRC_DIR=../src
 


### PR DESCRIPTION
This flag is problematic when building the library because it causes
crashes if an application using the library is built without it. It
should no longer be needed because attribute declarations were
recently added to structs that need packing. Note that #pragma pack
is also supported by GCC, hence the same approach could have been
used for both MSVC and GCC.
It is highly undesirable to use -fpack-struct=1 for applications because
that alignment is generally not efficient for in-memory data, and should
only be used if a data structure is used on the wire.