### PR TITLE
Update VS 2019 solution to match Makefile and bump version

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -43,7 +43,7 @@ extern "C" {
 #endif
 
 // Version of the library
-#define VERSION "1.2.0"
+#define VERSION "1.3.0"
 
 // .NET 2005 C++ wants structures that are passed as function parameters to be declared
 // as public.  .NET 2003 and native C pukes on that. C++ Interop doesn't seem to care.

--- a/src/irig106dll.def
+++ b/src/irig106dll.def
@@ -96,15 +96,14 @@ EXPORTS
 ; i106_decode_pcmf1
     enI106_Decode_FirstPcmF1
     enI106_Decode_NextPcmF1
-    PcmF1FirstRun
     DecodeMinorFrame_PcmF1
-    Set_PcmF1_Attributes
-    PcmCheckParity
-    PrepareNewMinorFrameCollection
-    GetNextBit
-    IsSyncWordFound
-    RenewSyncCounters
+    Set_Attributes_PcmF1
+    Set_Attributes_Ext_PcmF1
+    CreateOutputBuffers_PcmF1
+    FreeOutputBuffers_PcmF1
+    CheckParity_PcmF1
     SwapBytes_PcmF1
+    SwapShortWords_PcmF1
 
 ; i106_decode_can
     enI106_Decode_FirstCan

--- a/src/irig106dll.def
+++ b/src/irig106dll.def
@@ -85,19 +85,27 @@ EXPORTS
     enI106_Decode_FirstArinc429F0
     enI106_Decode_NextArinc429F0
 
+; i106_decode_uart
+    enI106_Decode_FirstUartF0
+    enI106_Decode_NextUartF0
+
+; i106_decode_discrete
+    enI106_Decode_FirstDiscreteF1
+    enI106_Decode_NextDiscreteF1
+
 ; i106_decode_pcmf1
-;    enI106_Decode_FirstPcmF1
-;    enI106_Decode_NextPcmF1 
-;    PcmF1FirstRun
-;    DecodeMinorFrame_PcmF1
-;    Set_PcmF1_Attributes
-;    PcmCheckParity
-;    PrepareNewMinorFrameCollection
-;    GetNextBit
-;    IsSyncWordFound
-;    RenewSyncCounters
-;    SwapBytes_PcmF1
-    
+    enI106_Decode_FirstPcmF1
+    enI106_Decode_NextPcmF1
+    PcmF1FirstRun
+    DecodeMinorFrame_PcmF1
+    Set_PcmF1_Attributes
+    PcmCheckParity
+    PrepareNewMinorFrameCollection
+    GetNextBit
+    IsSyncWordFound
+    RenewSyncCounters
+    SwapBytes_PcmF1
+
 ; i106_decode_can
-;    enI106_Decode_FirstCan
-;    enI106_Decode_NextCan
+    enI106_Decode_FirstCan
+    enI106_Decode_NextCan

--- a/vs2019/irig106dll.vcxproj
+++ b/vs2019/irig106dll.vcxproj
@@ -30,7 +30,11 @@
     <ClCompile Include="..\src\i106_decode_pcmf1.c" />
     <ClCompile Include="..\src\i106_decode_time.c" />
     <ClCompile Include="..\src\i106_decode_tmats.c" />
+    <ClCompile Include="..\src\i106_decode_tmats_b.c" />
+    <ClCompile Include="..\src\i106_decode_tmats_c.c" />
+    <ClCompile Include="..\src\i106_decode_tmats_d.c" />
     <ClCompile Include="..\src\i106_decode_tmats_g.c" />
+    <ClCompile Include="..\src\i106_decode_tmats_m.c" />
     <ClCompile Include="..\src\i106_decode_tmats_p.c" />
     <ClCompile Include="..\src\i106_decode_tmats_r.c" />
     <ClCompile Include="..\src\i106_decode_uart.c" />
@@ -59,8 +63,12 @@
     <ClInclude Include="..\src\i106_decode_pcmf1.h" />
     <ClInclude Include="..\src\i106_decode_time.h" />
     <ClInclude Include="..\src\i106_decode_tmats.h" />
+    <ClInclude Include="..\src\i106_decode_tmats_b.h" />
+    <ClInclude Include="..\src\i106_decode_tmats_c.h" />
     <ClInclude Include="..\src\i106_decode_tmats_common.h" />
+    <ClInclude Include="..\src\i106_decode_tmats_d.h" />
     <ClInclude Include="..\src\i106_decode_tmats_g.h" />
+    <ClInclude Include="..\src\i106_decode_tmats_m.h" />
     <ClInclude Include="..\src\i106_decode_tmats_p.h" />
     <ClInclude Include="..\src\i106_decode_tmats_r.h" />
     <ClInclude Include="..\src\i106_decode_uart.h" />

--- a/vs2019/irig106lib.vcxproj
+++ b/vs2019/irig106lib.vcxproj
@@ -162,7 +162,11 @@
     <ClCompile Include="..\src\i106_decode_pcmf1.c" />
     <ClCompile Include="..\src\i106_decode_time.c" />
     <ClCompile Include="..\src\i106_decode_tmats.c" />
+    <ClCompile Include="..\src\i106_decode_tmats_b.c" />
+    <ClCompile Include="..\src\i106_decode_tmats_c.c" />
+    <ClCompile Include="..\src\i106_decode_tmats_d.c" />
     <ClCompile Include="..\src\i106_decode_tmats_g.c" />
+    <ClCompile Include="..\src\i106_decode_tmats_m.c" />
     <ClCompile Include="..\src\i106_decode_tmats_p.c" />
     <ClCompile Include="..\src\i106_decode_tmats_r.c" />
     <ClCompile Include="..\src\i106_decode_uart.c" />
@@ -186,8 +190,12 @@
     <ClInclude Include="..\src\i106_decode_pcmf1.h" />
     <ClInclude Include="..\src\i106_decode_time.h" />
     <ClInclude Include="..\src\i106_decode_tmats.h" />
+    <ClInclude Include="..\src\i106_decode_tmats_b.h" />
+    <ClInclude Include="..\src\i106_decode_tmats_c.h" />
     <ClInclude Include="..\src\i106_decode_tmats_common.h" />
+    <ClInclude Include="..\src\i106_decode_tmats_d.h" />
     <ClInclude Include="..\src\i106_decode_tmats_g.h" />
+    <ClInclude Include="..\src\i106_decode_tmats_m.h" />
     <ClInclude Include="..\src\i106_decode_tmats_p.h" />
     <ClInclude Include="..\src\i106_decode_tmats_r.h" />
     <ClInclude Include="..\src\i106_decode_uart.h" />


### PR DESCRIPTION
Updated VS 2019 solution to export same functions as gcc Makefile. 

Bump version to 1.3.0.

The older VS solutions still need to be updated but I don't have access to older VS versions anymore.