### PR TITLE
Pack UART curr msg struct on GCC

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -6,31 +6,31 @@
 
  All rights reserved.
 
- Redistribution and use in source and binary forms, with or without 
- modification, are permitted provided that the following conditions are 
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are
  met:
 
-   * Redistributions of source code must retain the above copyright 
+   * Redistributions of source code must retain the above copyright
      notice, this list of conditions and the following disclaimer.
 
-   * Redistributions in binary form must reproduce the above copyright 
-     notice, this list of conditions and the following disclaimer in the 
+   * Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
      documentation and/or other materials provided with the distribution.
 
-   * Neither the name Irig106.org nor the names of its contributors may 
-     be used to endorse or promote products derived from this software 
+   * Neither the name Irig106.org nor the names of its contributors may
+     be used to endorse or promote products derived from this software
      without specific prior written permission.
 
- This software is provided by the copyright holders and contributors 
- "as is" and any express or implied warranties, including, but not 
- limited to, the implied warranties of merchantability and fitness for 
- a particular purpose are disclaimed. In no event shall the copyright 
- owner or contributors be liable for any direct, indirect, incidental, 
- special, exemplary, or consequential damages (including, but not 
- limited to, procurement of substitute goods or services; loss of use, 
- data, or profits; or business interruption) however caused and on any 
- theory of liability, whether in contract, strict liability, or tort 
- (including negligence or otherwise) arising in any way out of the use 
+ This software is provided by the copyright holders and contributors
+ "as is" and any express or implied warranties, including, but not
+ limited to, the implied warranties of merchantability and fitness for
+ a particular purpose are disclaimed. In no event shall the copyright
+ owner or contributors be liable for any direct, indirect, incidental,
+ special, exemplary, or consequential damages (including, but not
+ limited to, procurement of substitute goods or services; loss of use,
+ data, or profits; or business interruption) however caused and on any
+ theory of liability, whether in contract, strict liability, or tort
+ (including negligence or otherwise) arising in any way out of the use
  of this software, even if advised of the possibility of such damage.
 
  ****************************************************************************/
@@ -43,7 +43,7 @@ extern "C" {
 #endif
 
 // Version of the library
-#define VERSION "1.1.0"
+#define VERSION "1.2.0"
 
 // .NET 2005 C++ wants structures that are passed as function parameters to be declared
 // as public.  .NET 2003 and native C pukes on that. C++ Interop doesn't seem to care.
@@ -80,7 +80,7 @@ extern "C" {
  * non-standard stricmp(). Fix it up with a macro if necessary
  */
 
-#if defined(_MSC_VER) 
+#if defined(_MSC_VER)
 #define strcasecmp(s1, s2)          _stricmp(s1, s2)
 #define strncasecmp(s1, s2, n)      _strnicmp(s1, s2, n)
 #pragma warning(disable : 4996)

--- a/src/config.h
+++ b/src/config.h
@@ -43,7 +43,7 @@ extern "C" {
 #endif
 
 // Version of the library
-#define VERSION "1.2.0"
+#define VERSION "1.3.0"
 
 // .NET 2005 C++ wants structures that are passed as function parameters to be declared
 // as public.  .NET 2003 and native C pukes on that. C++ Interop doesn't seem to care.

--- a/src/i106_decode_uart.h
+++ b/src/i106_decode_uart.h
@@ -1,36 +1,36 @@
 /****************************************************************************
 
- i106_decode_uart.h - 
+ i106_decode_uart.h -
 
  Copyright (c) 2005 Irig106.org
 
  All rights reserved.
 
- Redistribution and use in source and binary forms, with or without 
- modification, are permitted provided that the following conditions are 
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are
  met:
 
-   * Redistributions of source code must retain the above copyright 
+   * Redistributions of source code must retain the above copyright
      notice, this list of conditions and the following disclaimer.
 
-   * Redistributions in binary form must reproduce the above copyright 
-     notice, this list of conditions and the following disclaimer in the 
+   * Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
      documentation and/or other materials provided with the distribution.
 
-   * Neither the name Irig106.org nor the names of its contributors may 
-     be used to endorse or promote products derived from this software 
+   * Neither the name Irig106.org nor the names of its contributors may
+     be used to endorse or promote products derived from this software
      without specific prior written permission.
 
- This software is provided by the copyright holders and contributors 
- "as is" and any express or implied warranties, including, but not 
- limited to, the implied warranties of merchantability and fitness for 
- a particular purpose are disclaimed. In no event shall the copyright 
- owner or contributors be liable for any direct, indirect, incidental, 
- special, exemplary, or consequential damages (including, but not 
- limited to, procurement of substitute goods or services; loss of use, 
- data, or profits; or business interruption) however caused and on any 
- theory of liability, whether in contract, strict liability, or tort 
- (including negligence or otherwise) arising in any way out of the use 
+ This software is provided by the copyright holders and contributors
+ "as is" and any express or implied warranties, including, but not
+ limited to, the implied warranties of merchantability and fitness for
+ a particular purpose are disclaimed. In no event shall the copyright
+ owner or contributors be liable for any direct, indirect, incidental,
+ special, exemplary, or consequential damages (including, but not
+ limited to, procurement of substitute goods or services; loss of use,
+ data, or profits; or business interruption) however caused and on any
+ theory of liability, whether in contract, strict liability, or tort
+ (including negligence or otherwise) arising in any way out of the use
  of this software, even if advised of the possibility of such damage.
 
  ****************************************************************************/
@@ -64,10 +64,10 @@ extern "C" {
 /* UART Format 0 */
 
 /// UART Format 0 Channel Specific Data Word
-typedef struct 
+typedef struct
     {
-    uint32_t    Reserved     : 31;      
-    uint32_t    bIPH         :  1;      // Intra-Packet Header enabled    
+    uint32_t    Reserved     : 31;
+    uint32_t    bIPH         :  1;      // Intra-Packet Header enabled
 #if !defined(__GNUC__)
     } SuUartF0_ChanSpec;
 #else
@@ -75,12 +75,12 @@ typedef struct
 #endif
 
 /// UART Format 0 Intra-Packet Header
-typedef struct 
-    {    
+typedef struct
+    {
     uint16_t    uDataLength     : 16;    // Length of the UART data in bytes
     uint16_t    uSubchannel     : 14;    // Subchannel for the following data
     uint16_t    uReserved       : 1;
-    uint16_t    bParityError    : 1;     //Parity Error    
+    uint16_t    bParityError    : 1;     //Parity Error
 #if !defined(__GNUC__)
     } SuUartF0_Header;
 #else
@@ -97,25 +97,27 @@ typedef struct
     SuUartF0_Header       * psuUartHdr;     // Pointer to the Intra-Packet header
     uint8_t               * pauData;        // Pointer to the data
     SuTimeRef               suTimeRef;
+#if !defined(__GNUC__)
     } SuUartF0_CurrMsg;
-
+#else
+    } __attribute__ ((packed)) SuUartF0_CurrMsg;
+#endif
 
 #if defined(_MSC_VER)
 #pragma pack(pop)
 #endif
-
 
 /*
  * Function Declaration
  * --------------------
  */
 
-EnI106Status I106_CALL_DECL 
+EnI106Status I106_CALL_DECL
     enI106_Decode_FirstUartF0(SuI106Ch10Header         * psuHeader,
                               void                     * pvBuff,
                               SuUartF0_CurrMsg         * psuCurrMsg);
 
-EnI106Status I106_CALL_DECL 
+EnI106Status I106_CALL_DECL
     enI106_Decode_NextUartF0(SuUartF0_CurrMsg          * psuCurrMsg);
 
 #ifdef __cplusplus

--- a/src/irig106dll.def
+++ b/src/irig106dll.def
@@ -96,15 +96,14 @@ EXPORTS
 ; i106_decode_pcmf1
     enI106_Decode_FirstPcmF1
     enI106_Decode_NextPcmF1
-    PcmF1FirstRun
     DecodeMinorFrame_PcmF1
-    Set_PcmF1_Attributes
-    PcmCheckParity
-    PrepareNewMinorFrameCollection
-    GetNextBit
-    IsSyncWordFound
-    RenewSyncCounters
+    Set_Attributes_PcmF1
+    Set_Attributes_Ext_PcmF1
+    CreateOutputBuffers_PcmF1
+    FreeOutputBuffers_PcmF1
+    CheckParity_PcmF1
     SwapBytes_PcmF1
+    SwapShortWords_PcmF1
 
 ; i106_decode_can
     enI106_Decode_FirstCan

--- a/src/irig106dll.def
+++ b/src/irig106dll.def
@@ -1,7 +1,6 @@
 ; irig106dll.def : Declares the module parameters for the DLL.
 
 LIBRARY      "Irig106"
-DESCRIPTION  'Irig106 - IRIG106 Data File Windows Dynamic Link Library'
 
 EXPORTS
 ; irig106ch10

--- a/src/irig106dll.def
+++ b/src/irig106dll.def
@@ -85,19 +85,27 @@ EXPORTS
     enI106_Decode_FirstArinc429F0
     enI106_Decode_NextArinc429F0
 
+; i106_decode_uart
+    enI106_Decode_FirstUartF0
+    enI106_Decode_NextUartF0
+
+; i106_decode_discrete
+    enI106_Decode_FirstDiscreteF1
+    enI106_Decode_NextDiscreteF1
+
 ; i106_decode_pcmf1
-;    enI106_Decode_FirstPcmF1
-;    enI106_Decode_NextPcmF1 
-;    PcmF1FirstRun
-;    DecodeMinorFrame_PcmF1
-;    Set_PcmF1_Attributes
-;    PcmCheckParity
-;    PrepareNewMinorFrameCollection
-;    GetNextBit
-;    IsSyncWordFound
-;    RenewSyncCounters
-;    SwapBytes_PcmF1
-    
+    enI106_Decode_FirstPcmF1
+    enI106_Decode_NextPcmF1
+    PcmF1FirstRun
+    DecodeMinorFrame_PcmF1
+    Set_PcmF1_Attributes
+    PcmCheckParity
+    PrepareNewMinorFrameCollection
+    GetNextBit
+    IsSyncWordFound
+    RenewSyncCounters
+    SwapBytes_PcmF1
+
 ; i106_decode_can
-;    enI106_Decode_FirstCan
-;    enI106_Decode_NextCan
+    enI106_Decode_FirstCan
+    enI106_Decode_NextCan

--- a/vs2019/irig106dll.vcxproj
+++ b/vs2019/irig106dll.vcxproj
@@ -30,7 +30,11 @@
     <ClCompile Include="..\src\i106_decode_pcmf1.c" />
     <ClCompile Include="..\src\i106_decode_time.c" />
     <ClCompile Include="..\src\i106_decode_tmats.c" />
+    <ClCompile Include="..\src\i106_decode_tmats_b.c" />
+    <ClCompile Include="..\src\i106_decode_tmats_c.c" />
+    <ClCompile Include="..\src\i106_decode_tmats_d.c" />
     <ClCompile Include="..\src\i106_decode_tmats_g.c" />
+    <ClCompile Include="..\src\i106_decode_tmats_m.c" />
     <ClCompile Include="..\src\i106_decode_tmats_p.c" />
     <ClCompile Include="..\src\i106_decode_tmats_r.c" />
     <ClCompile Include="..\src\i106_decode_uart.c" />
@@ -59,8 +63,12 @@
     <ClInclude Include="..\src\i106_decode_pcmf1.h" />
     <ClInclude Include="..\src\i106_decode_time.h" />
     <ClInclude Include="..\src\i106_decode_tmats.h" />
+    <ClInclude Include="..\src\i106_decode_tmats_b.h" />
+    <ClInclude Include="..\src\i106_decode_tmats_c.h" />
     <ClInclude Include="..\src\i106_decode_tmats_common.h" />
+    <ClInclude Include="..\src\i106_decode_tmats_d.h" />
     <ClInclude Include="..\src\i106_decode_tmats_g.h" />
+    <ClInclude Include="..\src\i106_decode_tmats_m.h" />
     <ClInclude Include="..\src\i106_decode_tmats_p.h" />
     <ClInclude Include="..\src\i106_decode_tmats_r.h" />
     <ClInclude Include="..\src\i106_decode_uart.h" />

--- a/vs2019/irig106dll.vcxproj
+++ b/vs2019/irig106dll.vcxproj
@@ -135,7 +135,7 @@
     <LinkIncremental>true</LinkIncremental>
     <IntDir>$(SolutionDir)dll64\$(Configuration)\</IntDir>
     <OutDir>$(SolutionDir)dll64\$(Configuration)\</OutDir>
-    <TargetName>irig106-x64</TargetName>
+    <TargetName>irig106</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LinkIncremental>false</LinkIncremental>
@@ -147,7 +147,7 @@
     <LinkIncremental>false</LinkIncremental>
     <IntDir>$(SolutionDir)dll64\$(Configuration)\</IntDir>
     <OutDir>$(SolutionDir)dll64\$(Configuration)\</OutDir>
-    <TargetName>irig106-x64</TargetName>
+    <TargetName>irig106</TargetName>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>

--- a/vs2019/irig106lib.vcxproj
+++ b/vs2019/irig106lib.vcxproj
@@ -162,7 +162,11 @@
     <ClCompile Include="..\src\i106_decode_pcmf1.c" />
     <ClCompile Include="..\src\i106_decode_time.c" />
     <ClCompile Include="..\src\i106_decode_tmats.c" />
+    <ClCompile Include="..\src\i106_decode_tmats_b.c" />
+    <ClCompile Include="..\src\i106_decode_tmats_c.c" />
+    <ClCompile Include="..\src\i106_decode_tmats_d.c" />
     <ClCompile Include="..\src\i106_decode_tmats_g.c" />
+    <ClCompile Include="..\src\i106_decode_tmats_m.c" />
     <ClCompile Include="..\src\i106_decode_tmats_p.c" />
     <ClCompile Include="..\src\i106_decode_tmats_r.c" />
     <ClCompile Include="..\src\i106_decode_uart.c" />
@@ -186,8 +190,12 @@
     <ClInclude Include="..\src\i106_decode_pcmf1.h" />
     <ClInclude Include="..\src\i106_decode_time.h" />
     <ClInclude Include="..\src\i106_decode_tmats.h" />
+    <ClInclude Include="..\src\i106_decode_tmats_b.h" />
+    <ClInclude Include="..\src\i106_decode_tmats_c.h" />
     <ClInclude Include="..\src\i106_decode_tmats_common.h" />
+    <ClInclude Include="..\src\i106_decode_tmats_d.h" />
     <ClInclude Include="..\src\i106_decode_tmats_g.h" />
+    <ClInclude Include="..\src\i106_decode_tmats_m.h" />
     <ClInclude Include="..\src\i106_decode_tmats_p.h" />
     <ClInclude Include="..\src\i106_decode_tmats_r.h" />
     <ClInclude Include="..\src\i106_decode_uart.h" />


### PR DESCRIPTION
So that it is packed the same with GCC and VS. So I can use with `python.ctypes`.

After merging #20, this PR's diff will be simplified.