### PR TITLE
Fix/faster tmats malloc

### DIFF
--- a/src/i106_decode_tmats.c
+++ b/src/i106_decode_tmats.c
@@ -1135,22 +1135,18 @@ void I106_CALL_DECL
 void * TmatsMalloc(size_t iSize)
     {
     void            * pvNewBuff;
-    SuMemBlock     ** ppsuCurrMemBlock;
+    SuMemBlock      * psuNewMemBlock;
 
     // Malloc the new memory
     pvNewBuff = malloc(iSize);
     assert(pvNewBuff != NULL);
 
-    // Walk to (and point to) the last linked memory block
-    ppsuCurrMemBlock = &m_psuTmatsInfo->psuFirstMemBlock;
-    while (*ppsuCurrMemBlock != NULL)
-        ppsuCurrMemBlock = &(*ppsuCurrMemBlock)->psuNextMemBlock;
-        
     // Populate the memory block struct
-    *ppsuCurrMemBlock = (SuMemBlock *)malloc(sizeof(SuMemBlock));
-    assert(*ppsuCurrMemBlock != NULL);
-    (*ppsuCurrMemBlock)->pvMemBlock      = pvNewBuff;
-    (*ppsuCurrMemBlock)->psuNextMemBlock = NULL;
+    psuNewMemBlock = (SuMemBlock *)malloc(sizeof(SuMemBlock));
+    assert(psuNewMemBlock != NULL);
+    psuNewMemBlock->pvMemBlock       = pvNewBuff;
+    psuNewMemBlock->psuNextMemBlock  = m_psuTmatsInfo->psuFirstMemBlock;
+    m_psuTmatsInfo->psuFirstMemBlock = psuNewMemBlock;
 
     return pvNewBuff;
     }

--- a/src/i106_decode_tmats.c
+++ b/src/i106_decode_tmats.c
@@ -207,7 +207,8 @@ EnI106Status I106_CALL_DECL
     szCodeName = malloc(ulCodeLen);
     while (iLineIdx < psuTmatsInfo->ulTmatsLines)
         {
-        strncpy_s(szCodeName, ulCodeLen, psuTmatsInfo->pasuTmatsLines[iLineIdx].szCodeName, ulCodeLen);
+        strncpy(szCodeName, psuTmatsInfo->pasuTmatsLines[iLineIdx].szCodeName, ulCodeLen);
+        szCodeName[ulCodeLen-1] = 0;
         szDataItem = psuTmatsInfo->pasuTmatsLines[iLineIdx].szDataItem;
 
         // Decode comments

--- a/src/i106_decode_tmats.c
+++ b/src/i106_decode_tmats.c
@@ -183,6 +183,7 @@ EnI106Status I106_CALL_DECL
     {
     unsigned long       iLineIdx;
     char              * szCodeName;
+    size_t              ulCodeLen;
     char              * szDataItem;
     int                 bParseError;
 
@@ -201,10 +202,12 @@ EnI106Status I106_CALL_DECL
 
     // Step through the array of TMATS lines
     iLineIdx = 0;
+    // we retain ownership of buffer; valid code names are short
+    ulCodeLen = 1024;
+    szCodeName = malloc(ulCodeLen);
     while (iLineIdx < psuTmatsInfo->ulTmatsLines)
         {
-        // Code Name get parsed some more so make a copy of it
-        szCodeName = strdup(psuTmatsInfo->pasuTmatsLines[iLineIdx].szCodeName);
+        strncpy_s(szCodeName, ulCodeLen, psuTmatsInfo->pasuTmatsLines[iLineIdx].szCodeName, ulCodeLen);
         szDataItem = psuTmatsInfo->pasuTmatsLines[iLineIdx].szDataItem;
 
         // Decode comments
@@ -287,6 +290,7 @@ EnI106Status I106_CALL_DECL
 
         } // end looping forever on reading TMATS buffer
 
+    free(szCodeName);
 
     // Figure out the TMATS version
     if (psuTmatsInfo->psuFirstGRecord->szIrig106Rev != NULL)


### PR DESCRIPTION
It is faster to maintain a pointer to the most recently allocated block to avoid repeatedly traversing the list during TmatsMalloc. Significant time improvement (O(n) instead of O(n^2)) when processing very large TMATS files.