### PR TITLE
networking and multicast for mingw windows

### DIFF
--- a/src/i106_data_stream.c
+++ b/src/i106_data_stream.c
@@ -42,20 +42,21 @@
 //#include <sys/types.h>
 //#include <sys/stat.h>
 
-#if defined(__GNUC__)
+#if !defined(_WIN32)
 #define SOCKET            int
 #define INVALID_SOCKET    -1
 #define SOCKET_ERROR      -1
 #define SOCKADDR          struct sockaddr
 #include <unistd.h>
 #include <netinet/in.h>
+#include <arpa/inet.h>
 #include <sys/socket.h>
 #endif
 
 #include <assert.h>
 
 #if defined(_WIN32)
-#define WIN32_LEAN_AND_MEAN		// Exclude rarely-used stuff from Windows headers
+#define WIN32_LEAN_AND_MEAN     // Exclude rarely-used stuff from Windows headers
 #include <windows.h>
 #include <winsock2.h>
 #include <ws2tcpip.h>
@@ -86,6 +87,12 @@
 
 #include "config.h"
 #include "i106_stdint.h"
+#ifndef MULTICAST_LISTEN_INTERFACE
+#define MULTICAST_LISTEN_INTERFACE "192.168.0.1"
+#endif
+#ifndef MULTICAST_BROADCAST_ADDRESS
+#define MULTICAST_BROADCAST_ADDRESS "239.0.1.1"
+#endif
 
 #include "irig106ch10.h"
 #include "i106_time.h"
@@ -101,7 +108,7 @@ namespace Irig106 {
  */
 
 // Make a min() function
-#if defined(_WIN32)
+#if defined(_MSC_VER)
 #define MIN(X, Y)   min(X, Y)
 #else
 #define MIN(X, Y) (((X) < (Y)) ? (X) : (Y))
@@ -156,6 +163,8 @@ typedef struct
 
 static int                  m_bHandlesInited = bFALSE;
 static SuI106Ch10NetHandle  m_suNetHandle[MAX_HANDLES];
+const char*                 m_aucMcastInterface = MULTICAST_LISTEN_INTERFACE;
+const char*                 m_aucMcastBcastAddr = MULTICAST_BROADCAST_ADDRESS;
 
 /*
  * Function Declaration
@@ -175,7 +184,7 @@ EnI106Status I106_CALL_DECL
     int                     iIdx;
     int                     iResult;
     struct sockaddr_in      ServerAddr;
-#if defined(_MSC_VER) 
+#if defined(_WIN32)
     WORD                    wVersionRequested;
     WSADATA                 wsaData;
 #endif
@@ -190,18 +199,7 @@ EnI106Status I106_CALL_DECL
         m_bHandlesInited = bTRUE;
         } // end if file handles not inited yet
 
-
-#ifdef MULTICAST
-    int                     iInterfaceIdx;
-    int                     iNumInterfaces;
-
-    struct in_addr          NetInterfaces[10];
-    struct in_addr          LocalInterfaceAddr;
-    struct in_addr          LocalInterfaceMask;
-    struct in_addr          IrigMulticastGroup;
-#endif
-
-#if defined(_MSC_VER) 
+#if defined(_WIN32)
     // Initialize WinSock, request version 2.2
     wVersionRequested = MAKEWORD(2, 2);
     iResult = WSAStartup(wVersionRequested, &wsaData);
@@ -218,7 +216,7 @@ EnI106Status I106_CALL_DECL
     if (m_suNetHandle[iHandle].suIrigSocket == INVALID_SOCKET) 
         {
 //        printf("socket() failed with error: %ld\n", WSAGetLastError());
-#if defined(_MSC_VER) 
+#if defined(_WIN32)
         WSACleanup();
 #endif
         return I106_OPEN_ERROR;
@@ -233,7 +231,7 @@ EnI106Status I106_CALL_DECL
     if (iResult == SOCKET_ERROR) 
         {
 //        printf("bind() failed with error: %ld\n", WSAGetLastError());
-#if defined(_MSC_VER) 
+#if defined(_WIN32)
         closesocket(m_suNetHandle[iHandle].suIrigSocket);
         WSACleanup();
 #else
@@ -244,18 +242,10 @@ EnI106Status I106_CALL_DECL
 
 #ifdef MULTICAST
     // Put the appropriate interface into multicast receive mode
-    iNumInterfaces = GetInterfaces(NetInterfaces, 10);
-    LocalInterfaceAddr.s_addr = inet_addr("192.0.0.0");
-    LocalInterfaceMask.s_addr = inet_addr("255.0.0.0");
-    IrigMulticastGroup.s_addr = inet_addr("239.0.1.1");
-    for (iInterfaceIdx = 0; iInterfaceIdx < iNumInterfaces; iInterfaceIdx++)
-        {
-        if ((NetInterfaces[iInterfaceIdx].s_addr & LocalInterfaceMask.s_addr) == LocalInterfaceAddr.s_addr)
-            {
-            join_source_group(m_suNetHandle[iHandle].suIrigSocket, IrigMulticastGroup, NetInterfaces[iInterfaceIdx]);
-            break;
-            }
-        }
+    struct ip_mreq mreq;
+    mreq.imr_interface.s_addr = inet_addr(m_aucMcastInterface);
+    mreq.imr_multiaddr.s_addr = inet_addr(m_aucMcastBcastAddr);
+    setsockopt(m_suNetHandle[iHandle].suIrigSocket, IPPROTO_IP, IP_ADD_MEMBERSHIP, (char*)&mreq, sizeof(mreq));
 #endif
 
     // Make sure the receive buffer is big enough for at least one UDP packet
@@ -286,7 +276,7 @@ EnI106Status I106_CALL_DECL
 #ifdef SO_MAX_MSG_SIZE
     int                     iMaxMsgSizeLen;
 #endif
-#if defined(_MSC_VER) 
+#if defined(_WIN32)
     WORD                    wVersionRequested;
     WSADATA                 wsaData;
     DWORD                   iMaxMsgSize = 0;
@@ -307,7 +297,7 @@ EnI106Status I106_CALL_DECL
         } // end if file handles not inited yet
 
 
-#if defined(_MSC_VER) 
+#if defined(_WIN32)
     // Initialize WinSock, request version 2.2
     wVersionRequested = MAKEWORD(2, 2);
     iResult = WSAStartup(wVersionRequested, &wsaData);
@@ -324,7 +314,7 @@ EnI106Status I106_CALL_DECL
     if (m_suNetHandle[iHandle].suIrigSocket == INVALID_SOCKET) 
         {
 //        printf("socket() failed with error: %ld\n", WSAGetLastError());
-#if defined(_MSC_VER) 
+#if defined(_WIN32)
         WSACleanup();
 #endif
         return I106_OPEN_ERROR;
@@ -416,7 +406,7 @@ EnI106Status I106_CALL_DECL
             PCAP_SRC_FILE,  // we want to open a file
             NULL,           // remote host
             NULL,           // port on the remote host
-            szPcapFile,		// name of the file we want to open
+            szPcapFile,     // name of the file we want to open
             szErrBuf);      // error buffer
     if (iStatus != 0) 
         return I106_OPEN_ERROR;
@@ -426,7 +416,7 @@ EnI106Status I106_CALL_DECL
             szSource,       // name of the device
             65536,          // portion of the packet to capture
                             // 65536 guarantees that the whole packet will be captured on all the link layers
-            PCAP_OPENFLAG_PROMISCUOUS, 	// promiscuous mode
+            PCAP_OPENFLAG_PROMISCUOUS,  // promiscuous mode
             1000,           // read timeout
             NULL,           // authentication on the remote machine
             szErrBuf);      // error buffer
@@ -442,6 +432,7 @@ EnI106Status I106_CALL_DECL
         return I106_OPEN_ERROR;
 
 #else
+    (void)szPcapFile;
     return I106_UNSUPPORTED;
 
 #endif // NPCAP / LPCAP
@@ -469,25 +460,17 @@ EnI106Status I106_CALL_DECL
 
 #ifdef MULTICAST
     // Restore the appropriate interface out of multicast receive mode
-    iNumInterfaces = GetInterfaces(NetInterfaces, 10);
-    LocalInterfaceAddr.s_addr = inet_addr("192.0.0.0");
-    LocalInterfaceMask.s_addr = inet_addr("255.0.0.0");
-    IrigMulticastGroup.s_addr = inet_addr("224.0.0.1");
-    for (iInterfaceIdx = 0; iInterfaceIdx < iNumInterfaces; iInterfaceIdx++)
-        {
-        if ((NetInterfaces[iInterfaceIdx].s_addr & LocalInterfaceMask.s_addr) == LocalInterfaceAddr.s_addr)
-            {
-            leave_source_group(IrigSocket, IrigMulticastGroup, NetInterfaces[iInterfaceIdx]);
-            break;
-            }
-        }
+    struct ip_mreq mreq;
+    mreq.imr_interface.s_addr = inet_addr(m_aucMcastInterface);
+    mreq.imr_multiaddr.s_addr = inet_addr(m_aucMcastBcastAddr);
+    setsockopt(m_suNetHandle[iHandle].suIrigSocket, IPPROTO_IP, IP_DROP_MEMBERSHIP, (char*)&mreq, sizeof(mreq));
 #endif
 
     switch (m_suNetHandle[iHandle].enNetMode)
         {
         case I106_READ_NET_STREAM :
             // Close the receive socket
-#if defined(_MSC_VER) 
+#if defined(_WIN32)
             closesocket(m_suNetHandle[iHandle].suIrigSocket);
             WSACleanup();
 #else
@@ -501,7 +484,7 @@ EnI106Status I106_CALL_DECL
 
         case I106_WRITE_NET_STREAM :
             // Close the transmit socket
-#if defined(_MSC_VER) 
+#if defined(_WIN32)
             closesocket(m_suNetHandle[iHandle].suIrigSocket);
             WSACleanup();
 #else
@@ -576,7 +559,7 @@ static EnI106Status
         {
         case I106_READ_NET_STREAM :
             iResult = recvfrom(psuNetHandle->suIrigSocket, (char *)pvBuffer1, ulBufLen1, MSG_PEEK, NULL, NULL);
-#if defined(_MSC_VER)
+#if defined(_WIN32)
             // Make the WinSock return code more like POSIX to simplify the logic
             // WinSock returns -1 when the message is larger than the buffer
             // Thus, (iResult==-1) && WSAEMSGSIZE is expected, as we're only reading the header
@@ -671,6 +654,7 @@ static EnI106Status
             break;
 
         default :
+            enReturnStatus = I106_UNSUPPORTED;
             break;
 
         } // end switch on read type
@@ -705,7 +689,7 @@ static EnI106Status
                  unsigned long          ulBufLen2,
                  unsigned long        * pulBytesRcvdOut)
     {
-#if defined(_MSC_VER)
+#if defined(_WIN32)
     WSABUF         asuUdpRcvBuffs[2];
     DWORD          UdpRcvFlags;
     DWORD          dwBytesRcvd;
@@ -720,7 +704,7 @@ static EnI106Status
     switch (psuNetHandle->enNetMode)
         {
         case I106_READ_NET_STREAM :
-#if defined(_MSC_VER)
+#if defined(_WIN32)
 
             UdpRcvFlags = 0;
 
@@ -870,7 +854,7 @@ int I106_CALL_DECL
             // Peek at the message to determine the msg type (segmented or non-segmented)
 #if 0
                 iResult = recvfrom(m_suNetHandle[iHandle].suIrigSocket, (char *)&suUdpSeg, sizeof(suUdpSeg), MSG_PEEK, NULL, NULL);
-#if defined(_MSC_VER)
+#if defined(_WIN32)
                 // Make the WinSock return code more like POSIX to simplify the logic
                 // WinSock returns -1 when the message is larger than the buffer
                 // Thus, (iResult==-1) && WSAEMSGSIZE is expected, as we're only reading the header
@@ -1235,7 +1219,7 @@ EnI106Status I106_CALL_DECL
     {
     EnI106Status        enReturnStatus;
 
-#if defined(_MSC_VER)
+#if defined(_WIN32)
 //  SOCKET_ADDRESS      suMsSendIpAddress;
     WSAMSG              suMsMsgInfo;
     WSABUF              suMsBuffInfo[2];
@@ -1254,7 +1238,7 @@ EnI106Status I106_CALL_DECL
     suUdpHeaderNonF1Seg.uUdpSeqNum  = m_suNetHandle[iHandle].uUdpSeqNum;
 
     // Send the IRIG UDP packet
-#if defined(_MSC_VER)
+#if defined(_WIN32)
     // I don't really want or need control data. I hope this doesn't 
     // cause WSASendMsg() to fail.
     suMsControl.buf           = NULL;
@@ -1306,7 +1290,7 @@ EnI106Status I106_CALL_DECL
     uint32_t            uSendSize;
     SuI106Ch10Header  * psuHeader;
 
-#if defined(_MSC_VER)
+#if defined(_WIN32)
     int                 iSendStatus;
     WSAMSG              suMsMsgInfo;
     WSABUF              suMsBuffInfo[2];
@@ -1337,7 +1321,7 @@ EnI106Status I106_CALL_DECL
         pchBuffer  = (char *)pvBuffer + uBuffIdx;
 
         uSendSize = MIN(m_suNetHandle[iHandle].uMaxUdpSize, uBuffSize-uBuffIdx);
-#if defined(_MSC_VER)
+#if defined(_WIN32)
         // I don't really want or need control data. I hope this doesn't 
         // cause WSASendMsg() to fail.
         suMsControl.buf           = NULL;

--- a/src/i106_decode_message.c
+++ b/src/i106_decode_message.c
@@ -109,7 +109,7 @@ EnI106Status I106_CALL_DECL
          psuMsg->psuMSGF0Hdr->uMsgLength) > psuMsg->ulDataLen)
         return I106_BUFFER_OVERRUN;
 
-    psuMsg->pauData = psuMsg->psuMSGF0Hdr +1;
+    psuMsg->pauData = (uint8_t*)(psuMsg->psuMSGF0Hdr +1);
 
     return I106_OK;
     }
@@ -147,7 +147,7 @@ EnI106Status I106_CALL_DECL
          psuMsg->psuMSGF0Hdr->uMsgLength) > psuMsg->ulDataLen)
         return I106_BUFFER_OVERRUN;
 
-    psuMsg->pauData = psuMsg->psuMSGF0Hdr + 1;
+    psuMsg->pauData = (uint8_t*)(psuMsg->psuMSGF0Hdr + 1);
 
     return I106_OK;
     }

--- a/src/i106_decode_pcmf1.c
+++ b/src/i106_decode_pcmf1.c
@@ -385,7 +385,7 @@ EnI106Status I106_CALL_DECL Set_Attributes_PcmF1(SuRDataSource * psuRDataSrc, Su
     if(psuPRecord->szWordTransferOrder != NULL)    // P-x\F2 most significant bit "M", least significant bit "L". default: M
     {
         /*
-        Measurement Transfer Order. Which bit is being transferred first is specified as – Most Significant Bit (M), 
+        Measurement Transfer Order. Which bit is being transferred first is specified as â€“ Most Significant Bit (M), 
         Least Significant Bit (L), or Default (D). The default is specified in the P-Group - (P-x\F2:M).
         D-1\MN3-1-1:M;
         */
@@ -434,7 +434,7 @@ EnI106Status I106_CALL_DECL Set_Attributes_PcmF1(SuRDataSource * psuRDataSrc, Su
 
     if(psuPRecord->szInSyncCrit != NULL)
     {
-        // to declare that the system is in sync – First good sync (0), Check (1 or greater), or Not specified (NS).
+        // to declare that the system is in sync â€“ First good sync (0), Check (1 or greater), or Not specified (NS).
         psuPcmF1_Attributes->ulMinSyncs = 0; // Minimal number of syncs P-x\SYNC1;
     }
         

--- a/src/i106_index.c
+++ b/src/i106_index.c
@@ -43,7 +43,7 @@
 #include <stdio.h>
 #include <ctype.h>
 
-#if !defined(__GNUC__)
+#if defined(_WIN32)
 #include <io.h>
 #endif
 
@@ -264,7 +264,7 @@ EnI106Status I106_CALL_DECL enReadIndexes(const int iHandle)
     // Save this file offset
     enStatus = enI106Ch10GetPos(iHandle, &llCurrRootIndexOffset);
 
-	// Root packet found so start processing root index packets
+    // Root packet found so start processing root index packets
     while (1==1)
         {
         // Process the root packet at the given offset
@@ -288,7 +288,7 @@ EnI106Status I106_CALL_DECL enReadIndexes(const int iHandle)
     // Restore the file position
     enI106Ch10SetPos(iHandle, llStartingFileOffset);
 
-	return enStatus;
+    return enStatus;
     } // end enReadIndexes()
 
 

--- a/src/irig106ch10.c
+++ b/src/irig106ch10.c
@@ -52,15 +52,11 @@
 #include <errno.h>
 #include <assert.h>
 
-#if defined(__GNUC__)
+#if !defined(_WIN32)
 #include <sys/io.h>
 #include <unistd.h>
 #else
 #include <io.h>
-#endif
-
-#if defined(_WIN32)
-//#include <Windows.h>
 #endif
 
 #if defined(IRIG_NETWORKING) & !defined(_WIN32)
@@ -182,7 +178,7 @@ EnI106Status I106_CALL_DECL
         {
 
         //// Try to open file
-#if defined(_MSC_VER)
+#if defined(_WIN32)
         iFlags = O_RDONLY | O_BINARY;
 #elif defined(__GNUC__)
         iFlags = O_RDONLY;  // | O_LARGEFILE; Replaced with #define _FILE_OFFSET_BITS 64
@@ -269,7 +265,7 @@ EnI106Status I106_CALL_DECL
         {
 
         /// Try to open file
-#if defined(_MSC_VER)
+#if defined(_WIN32)
         iFlags    = O_WRONLY | O_CREAT | _O_TRUNC | O_BINARY;
         iFileMode = _S_IREAD | _S_IWRITE;
 #elif defined(__GNUC__)
@@ -1338,7 +1334,7 @@ EnI106Status I106_CALL_DECL
     int64_t             llPos;
     SuI106Ch10Header    suHeader;
     int                 iReadCnt;  
-#if !defined(_MSC_VER)
+#if !defined(_WIN32)
     struct stat         suStatBuff;
 #endif
 
@@ -1376,7 +1372,7 @@ EnI106Status I106_CALL_DECL
         case I106_READ :
 
             // Figure out how big the file is and go to the end
-#if defined(_MSC_VER)       
+#if defined(_WIN32)
             llPos = _filelengthi64(g_suI106Handle[iHandle].iFile) - HEADER_SIZE;
 #else   
             fstat(g_suI106Handle[iHandle].iFile, &suStatBuff);
@@ -2014,7 +2010,7 @@ int I106_CALL_DECL
         {
 
         // Try opening and reading the index file
-#if defined(_MSC_VER)
+#if defined(_WIN32)
         iFlags = O_RDONLY | O_BINARY;
 #else
         iFlags = O_RDONLY;
@@ -2060,7 +2056,7 @@ int I106_CALL_DECL
     SuInOrderIndex    * psuIndex = &g_suI106Handle[iHandle].suInOrderIndex;
 
     // Write out an index file for use next time
-#if defined(_MSC_VER)
+#if defined(_WIN32)
     iFlags    = O_WRONLY | O_CREAT | O_BINARY;
         iFileMode = _S_IREAD | _S_IWRITE;
 #elif defined(__GNUC__)


### PR DESCRIPTION
When building with mingw on windows, `__GNUC__` is defined but we must use the Windows sockets api. The current proeprocessor checks for `__GNUC__` and falsely identifies the environment as non-windows. This pull request converts most

`#if defined(__GNUC__)`

for

`#if !defined(_WIN32)`

Additionaly, most checks for `_MSC_VER` are changed for `_WIN32` because mingw on windows does not define `_MSC_VER`.
 