### PR TITLE
Python decode improvements

### DIFF
--- a/python/Py106/MsgDecode1553.py
+++ b/python/Py106/MsgDecode1553.py
@@ -228,6 +228,7 @@ if __name__=='__main__':
 
     # Initialize counts variables
     TR = ("R", "T")
+    AB = ("A", "B")
     packet_count = 0
     msg_count = 0
 
@@ -254,9 +255,10 @@ if __name__=='__main__':
 #                time_utils.RelInt2IrigTime()
                 WC = decode1553.word_cnt(msg.pCmdWord1.contents.Value)
                 msg_time = time_utils.rel_int_to_irig_time(msg.p1553Hdr.contents.Field.PktTime)
-                sys.stdout.write("%s Ch %3i   %2i-%s-%02i-%02i (%04x)  " % (  \
+                sys.stdout.write("%s Ch %3i-%s   %2i-%s-%02i-%02i (%04x)  " % (  \
                     msg_time,                               \
                     pkt_io.header.ch_id,                    \
+                    AB[msg.p1553Hdr.contents.Field.BlockStatus.BusID], \
                     msg.pCmdWord1.contents.Field.RTAddr,    \
                     TR[msg.pCmdWord1.contents.Field.TR],    \
                     msg.pCmdWord1.contents.Field.SubAddr,   \

--- a/python/irig_1553_csv
+++ b/python/irig_1553_csv
@@ -310,7 +310,7 @@ def msg_1553_unpack(msg, decode1553, time_utils, pkt_io):
 
 statistics = collections.defaultdict(lambda: 0)
 headers = headers_1553()
-if not args.no_want_headers or args.debug_action:
+if not args.no_want_headers and not args.debug_action:
     print(args.field.join(headers))
 
 for fn in args.filename:
@@ -330,6 +330,7 @@ for fn in args.filename:
     for pkt_hdr in pkt_io.packet_headers():
         if args.debug_action == "dump_pkt_hdrs":
             print("Ch ID %3i  %s" % (pkt_io.header.ch_id, irig10.packet.DataType.type_name(pkt_hdr.data_type)))
+            continue
 
         if pkt_hdr.data_type != irig10.packet.DataType.MIL1553_FMT_1:
             continue


### PR DESCRIPTION
Add output of the redundant sub-channel [AB] to the MsgDecode1553.py

Also, when doing the documented debug_action "ancillary" tasks, don't do things which pollute the output stream for the anciliary tasks, like print headers, print 1553 payload, etc.
